### PR TITLE
build(gradle): configure compiler options for Java and Kotlin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,11 @@ configure(libraryProjects) {
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             freeCompilerArgs = listOf("-Xjsr305=strict", "-Xjvm-default=all-compatibility")
+            javaParameters = true
         }
+    }
+    tasks.withType<JavaCompile> {
+        options.compilerArgs.addAll(listOf("-parameters"))
     }
     tasks.withType<Test> {
         useJUnitPlatform()
@@ -86,9 +90,6 @@ configure(libraryProjects) {
         }
         // fix logging missing code for JacocoPlugin
         jvmArgs = listOf("-Dlogback.configurationFile=${rootProject.rootDir}/config/logback.xml")
-    }
-    tasks.withType<JavaCompile> {
-        options.compilerArgs.addAll(listOf("-parameters"))
     }
     dependencies {
         api(platform(dependenciesProject))


### PR DESCRIPTION
- Add javaParameters to Kotlin compiler options
- Move Java compiler arguments to the correct position
- Remove redundant JavaCompile task configuration