### PR TITLE
feat(core): implement status management for mutex retrieval service

### DIFF
--- a/simba-core/src/main/kotlin/me/ahoo/simba/core/MutexRetrievalService.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/core/MutexRetrievalService.kt
@@ -18,6 +18,7 @@ package me.ahoo.simba.core
  * @author ahoo wang
  */
 interface MutexRetrievalService : AutoCloseable {
+    val status: Status
     val retriever: MutexRetriever
     val mutex: String
         get() = retriever.mutex
@@ -44,6 +45,18 @@ interface MutexRetrievalService : AutoCloseable {
     }
 
     val running: Boolean
+        get() = status.isActive
+
     fun start()
     fun stop()
+
+    enum class Status {
+        INITIAL,
+        STARTING,
+        RUNNING,
+        STOPPING;
+
+        val isActive: Boolean
+            get() = this == STARTING || this == RUNNING
+    }
 }

--- a/simba-core/src/main/kotlin/me/ahoo/simba/locker/SimbaLocker.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/locker/SimbaLocker.kt
@@ -45,19 +45,15 @@ class SimbaLocker(
         val OWNER: AtomicReferenceFieldUpdater<SimbaLocker, Thread> = AtomicReferenceFieldUpdater.newUpdater(
             SimbaLocker::class.java,
             Thread::class.java,
-            "owner"
+            SimbaLocker::owner.name
         )
     }
 
-    private val contendService: MutexContendService
+    private val contendService: MutexContendService = contendServiceFactory.createMutexContendService(this)
 
     @Volatile
     @Suppress("unused")
     private var owner: Thread? = null
-
-    init {
-        contendService = contendServiceFactory.createMutexContendService(this)
-    }
 
     @Throws(Exception::class)
     override fun close() {
@@ -80,7 +76,7 @@ class SimbaLocker(
             LockSupport.parkNanos(this, timeout.toNanos())
             if (!contendService.isOwner) {
                 throw TimeoutException(
-                    "Could not acquire [$contenderId]@mutex:[$mutex] within timeout of %${timeout.toMillis()}ms"
+                    "Could not acquire [$contenderId]@mutex:[$mutex] within timeout of ${timeout.toMillis()}ms"
                 )
             }
         } else {

--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
@@ -72,6 +72,7 @@ class JdbcMutexContendService(
         mutexOwnerRepository.release(mutex, contenderId)
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun safeHandleContend() {
         try {
             val mutexOwner = contend()

--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt
@@ -85,6 +85,7 @@ class JdbcMutexOwnerRepository(private val dataSource: DataSource) : MutexOwnerR
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun tryInitMutex(mutex: String): Boolean {
         return try {
             initMutex(mutex)
@@ -129,6 +130,7 @@ class JdbcMutexOwnerRepository(private val dataSource: DataSource) : MutexOwnerR
         dataSource.connection.use { connection -> return ensureOwner(connection, mutex) }
     }
 
+    @Suppress("SwallowedException")
     @Throws(SQLException::class)
     private fun ensureOwner(connection: Connection, mutex: String): MutexOwnerEntity {
         return try {

--- a/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
+++ b/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
@@ -106,24 +106,25 @@ class SpringRedisMutexContendService(
     private fun nextSchedule(nextDelay: Long) {
         if (log.isDebugEnabled) {
             log.debug(
-                "nextSchedule - mutex:[{}] contender_id:[{}] delay:[{}ms].",
+                "nextSchedule - mutex:[{}] contender_id:[{}] status:[{}] delay:[{}ms].",
                 mutex,
                 contenderId,
+                status,
                 nextDelay
             )
         }
-        scheduleFuture = scheduledExecutorService.schedule<MutexOwner>({
-            if (!status.isActive) {
-                if (log.isWarnEnabled) {
-                    log.warn(
-                        "nextSchedule - mutex:[{}] contender_id:[{}] is not active[{}].",
-                        mutex,
-                        contenderId,
-                        status
-                    )
-                }
-                return@schedule MutexOwner.NONE
+        if (!status.isActive) {
+            if (log.isWarnEnabled) {
+                log.warn(
+                    "nextSchedule - mutex:[{}] contender_id:[{}] is not active[{}].",
+                    mutex,
+                    contenderId,
+                    status
+                )
             }
+            return
+        }
+        scheduleFuture = scheduledExecutorService.schedule<MutexOwner>({
             if (isOwner) {
                 return@schedule guard()
             }

--- a/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
+++ b/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
@@ -114,6 +114,14 @@ class SpringRedisMutexContendService(
         }
         scheduleFuture = scheduledExecutorService.schedule<MutexOwner>({
             if (!status.isActive) {
+                if (log.isWarnEnabled) {
+                    log.warn(
+                        "nextSchedule - mutex:[{}] contender_id:[{}] is not active[{}].",
+                        mutex,
+                        contenderId,
+                        status
+                    )
+                }
                 return@schedule MutexOwner.NONE
             }
             if (isOwner) {
@@ -244,7 +252,7 @@ class SpringRedisMutexContendService(
             if (!status.isActive) {
                 if (log.isWarnEnabled) {
                     log.warn(
-                        "onMessage - ignore - mutex:[{}] contender_id:[{}] status:[{}]",
+                        "onMessage - ignore - mutex:[{}] contender_id:[{}] is not active[{}].",
                         mutex,
                         contenderId,
                         status

--- a/simba-zookeeper/src/main/kotlin/me/ahoo/simba/zookeeper/ZookeeperMutexContendService.kt
+++ b/simba-zookeeper/src/main/kotlin/me/ahoo/simba/zookeeper/ZookeeperMutexContendService.kt
@@ -29,18 +29,12 @@ import java.util.concurrent.Executor
 class ZookeeperMutexContendService(
     contender: MutexContender,
     handleExecutor: Executor,
-    curatorFramework: CuratorFramework
-) : AbstractMutexContendService(contender, handleExecutor), LeaderLatchListener {
     private val curatorFramework: CuratorFramework
+) : AbstractMutexContendService(contender, handleExecutor), LeaderLatchListener {
 
     @Volatile
     private var leaderLatch: LeaderLatch? = null
-    private val mutexPath: String
-
-    init {
-        mutexPath = RESOURCE_PREFIX + contender.mutex
-        this.curatorFramework = curatorFramework
-    }
+    private val mutexPath: String = RESOURCE_PREFIX + contender.mutex
 
     override fun startContend() {
         leaderLatch = LeaderLatch(curatorFramework, mutexPath, contenderId)


### PR DESCRIPTION
- Add Status enum to MutexRetrievalService interface
- Implement status management in AbstractMutexRetrievalService
- Update start() and stop() methods to handle status transitions
- Add logging for status changes
- Improve error handling in mutex contention services
