### PR TITLE
build(deps): update dependencies and move logging implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,6 @@ configure(libraryProjects) {
         detektPlugins(platform(dependenciesProject))
         implementation("com.google.guava:guava")
         implementation("org.slf4j:slf4j-api")
-        implementation("io.github.oshai:kotlin-logging-jvm")
         testImplementation("ch.qos.logback:logback-classic")
         testImplementation("org.junit.jupiter:junit-jupiter-api")
         testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/simba-core/build.gradle.kts
+++ b/simba-core/build.gradle.kts
@@ -11,5 +11,6 @@
  * limitations under the License.
  */
 dependencies {
+    api("io.github.oshai:kotlin-logging-jvm")
     implementation("me.ahoo.cosid:cosid-core")
 }


### PR DESCRIPTION
- Remove `kotlin-logging-jvm` from the common dependencies
- Add `kotlin-logging-jvm` as an API dependency in `simba-core`
- Update `slf4j-api` to a newer version (if applicable)