### PR TITLE
ci: disable Codecov and Integration Test for pushes

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,5 @@
 name: Codecov
-on: [ pull_request ]
+on: [ push, pull_request ]
 jobs:
   codecov:
     name: Codecov

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,5 @@
 name: Codecov
-on: [ push, pull_request ]
+on: [ pull_request ]
 jobs:
   codecov:
     name: Codecov

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@
 #
 
 name: Integration Test
-on: [ push,pull_request ]
+on: [ pull_request ]
 jobs:
   simba-core-test:
     name: Simba Core Test


### PR DESCRIPTION
- Remove 'push' event from Codecov workflow trigger
- Remove 'push' event from Integration Test workflow trigger
