### PR TITLE
build(deps): add JUnit BOM and update test dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,7 @@ configure(libraryProjects) {
     }
     dependencies {
         api(platform(dependenciesProject))
+        testImplementation(platform(rootProject.libs.junit.bom))
         detektPlugins(platform(dependenciesProject))
         implementation("com.google.guava:guava")
         implementation("org.slf4j:slf4j-api")
@@ -103,6 +104,7 @@ configure(libraryProjects) {
         testImplementation("io.mockk:mockk") {
             exclude(group = "org.slf4j", module = "slf4j-api")
         }
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
         detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ testcontainers = "1.21.1"
 guava = "33.4.8-jre"
 commons-io = "2.19.0"
 kotlin-logging = "7.0.7"
+junit = "5.13.0"
 hamcrest = "3.0"
 mockk = "1.14.2"
 detekt-formatting = "1.23.8"
@@ -24,6 +25,7 @@ testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt-formatting" }


### PR DESCRIPTION
- Add JUnit BOM (Bill of Materials) to manage test dependencies
- Include junit-platform-launcher for test execution
- Update gradle/libs.versions.toml to include junit version
- Add junit-bom to dependencies in build.gradle.kts
