### PR TITLE
build(gradle): move Detekt configuration to root project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,16 @@ allprojects {
         mavenLocal()
         mavenCentral()
     }
+    apply<DetektPlugin>()
+    configure<DetektExtension> {
+        config.setFrom(files("${rootProject.rootDir}/config/detekt/detekt.yml"))
+        buildUponDefaultConfig = true
+        autoCorrect = true
+    }
+    dependencies {
+        detektPlugins(dependenciesProject)
+        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
+    }
 }
 
 configure(bomProjects) {
@@ -55,12 +65,6 @@ configure(bomProjects) {
 }
 
 configure(libraryProjects) {
-    apply<DetektPlugin>()
-    configure<DetektExtension> {
-        config.setFrom(files("${rootProject.rootDir}/config/detekt/detekt.yml"))
-        buildUponDefaultConfig = true
-        autoCorrect = true
-    }
     apply<DokkaPlugin>()
     apply<JacocoPlugin>()
     apply<JavaLibraryPlugin>()
@@ -94,7 +98,6 @@ configure(libraryProjects) {
     dependencies {
         api(platform(dependenciesProject))
         testImplementation(platform(rootProject.libs.junit.bom))
-        detektPlugins(platform(dependenciesProject))
         implementation("com.google.guava:guava")
         implementation("org.slf4j:slf4j-api")
         testImplementation("ch.qos.logback:logback-classic")
@@ -106,7 +109,6 @@ configure(libraryProjects) {
         }
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
     }
 }
 


### PR DESCRIPTION
- Move Detekt plugin application and configuration from libraryProjects to the root project
- Remove Detekt-related dependencies from libraryProjects
- Centralize Detekt setup for better maintainability and consistency across subprojects


