### PR TITLE
docs: optimize Simba skills metadata

### DIFF
--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": 1,
+  "plugins": [
+    {
+      "name": "ahoo-simba-skills",
+      "description": "Skills for using and testing Simba, a JVM distributed mutex and leader-election library with JDBC/MySQL, Redis, and Zookeeper backends.",
+      "skills": {
+        "include": [
+          "*"
+        ],
+        "exclude": [
+          "*-workspace"
+        ]
+      },
+      "keywords": [
+        "simba",
+        "distributed-lock",
+        "distributed-mutex",
+        "leader-election",
+        "jvm",
+        "kotlin",
+        "spring-boot",
+        "redis",
+        "jdbc",
+        "zookeeper"
+      ],
+      "category": "development",
+      "interface": {
+        "displayName": "Ahoo Simba Skills",
+        "capabilities": [
+          "Skills"
+        ],
+        "defaultPrompt": "Help me use Simba distributed locks, leader election, backend configuration, and tests for JVM applications."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      }
+    }
+  ]
+}

--- a/skills/simba-testing/SKILL.md
+++ b/skills/simba-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simba-testing
-description: Guide for testing Simba distributed lock code. Use this skill whenever writing or reviewing tests for classes that use Simba — MutexContender tests, SimbaLocker tests, AbstractScheduler tests, backend TCK conformance tests, or integration tests with real backends. Trigger on "test Simba", "distributed lock test", "leader election test", or when extending MutexContendServiceSpec.
+description: Guide for testing Simba distributed lock and leader-election code. Use when writing or reviewing tests for MutexContender, SimbaLocker, AbstractScheduler, backend TCK conformance via MutexContendServiceSpec, Redis/JDBC/Zookeeper integration tests, timing-sensitive lock behavior, or new Kotlin assertions in Simba-based code.
 ---
 
 # Testing Simba-Based Code
@@ -14,6 +14,11 @@ Simba testing has three layers:
 
 Choose the simplest layer that gives confidence. Most application code only needs unit tests with mocks. Backend implementors need TCK + integration tests.
 
+Before writing a test, decide:
+- **Application behavior**: mock `MutexContendServiceFactory`, capture the contender, and trigger callbacks directly.
+- **Backend implementation**: extend `MutexContendServiceSpec` and run against the real backend.
+- **Scheduler behavior**: verify leadership gating separately from the business logic in `work()`.
+
 ## Unit Tests with MockK
 
 For application code that injects `MutexContendServiceFactory`, mock it:
@@ -24,6 +29,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import me.ahoo.simba.core.MutexContendService
 import me.ahoo.simba.core.MutexContendServiceFactory
+import me.ahoo.simba.core.MutexContender
 import me.ahoo.simba.core.MutexOwner
 import me.ahoo.simba.core.MutexState
 
@@ -121,23 +127,11 @@ This gives you five standard tests:
 
 | Backend | External dependency | Notes |
 |---------|-------------------|-------|
-| Redis | Running Redis instance | Use Testcontainers or embedded Redis |
-| JDBC | Running MySQL instance | Init script: `simba-jdbc/src/init-script/init-simba-mysql.sql` |
+| Redis | Running Redis instance | Current repository tests use `RedisStandaloneConfiguration` defaults |
+| JDBC | Running MySQL instance | Current repository tests use `jdbc:mysql://localhost:3306/simba_db`, `root`/`root`; init script: `simba-jdbc/src/init-script/init-simba-mysql.sql` |
 | Zookeeper | None | Uses Curator's `TestingServer` (embedded) |
 
-For Redis and JDBC, use Testcontainers for CI:
-```kotlin
-@Testcontainers
-class JdbcMutexContendServiceTest : MutexContendServiceSpec() {
-    companion object {
-        @Container
-        val mysql = MySQLContainer("mysql:8.0")
-    }
-    override val mutexContendServiceFactory: MutexContendServiceFactory by lazy {
-        // create factory from mysql.jdbcUrl
-    }
-}
-```
+Do not silently add Testcontainers to this repository's tests. If CI isolation is required, add the dependency and Gradle wiring intentionally, then update the backend setup code and this skill together.
 
 ## AbstractScheduler Tests
 
@@ -169,7 +163,7 @@ fun `scheduler should run work only when leader`() {
 
 ## Assertion Style
 
-Use `fluent-assert` for all assertions:
+Use `fluent-assert` for new Kotlin assertions:
 ```kotlin
 import me.ahoo.test.asserts.assert
 
@@ -178,11 +172,11 @@ collection.assert().hasSize(3)
 bool.assert().isTrue()
 ```
 
-Do NOT use AssertJ's `assertThat()` — it's verbose and not null-safe in Kotlin.
+Do not churn existing Hamcrest/AssertJ assertions solely for style. When adding or touching assertions, prefer `.assert()` and keep the local test readable.
 
 ## Common Test Pitfalls
 
-1. **Timing-dependent tests**: Distributed lock tests are inherently timing-sensitive. Use generous timeouts (5-30s) and `CountDownLatch` / `CompletableFuture` rather than `Thread.sleep`.
+1. **Timing-dependent tests**: Distributed lock tests are inherently timing-sensitive. Use generous timeouts (5-30s) and prefer `CountDownLatch` / `CompletableFuture` over new `Thread.sleep` calls.
 2. **Shared mutex names**: Each test should use a unique mutex name to avoid cross-test interference. Use `"test-mutex-${UUID.randomUUID()}"`.
 3. **Resource cleanup**: Always stop/close services in `@AfterEach` to avoid leaked threads and held locks.
 4. **Mocking `MutexContendService` vs `MutexContendServiceFactory`**: Mock the factory (the DI seam), not the service directly. The factory is what application code injects.

--- a/skills/simba-testing/agents/openai.yaml
+++ b/skills/simba-testing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Simba Testing"
+  short_description: "Test Simba locking behavior"
+  default_prompt: "Use $simba-testing to write tests for a Simba scheduler or backend."

--- a/skills/simba/SKILL.md
+++ b/skills/simba/SKILL.md
@@ -1,11 +1,21 @@
 ---
 name: simba
-description: Guide for using the Simba distributed mutex / leader-election library in JVM projects. Use this skill whenever a developer is working with Simba — creating distributed locks, implementing leader election, configuring Simba backends (JDBC, Redis, Zookeeper), writing MutexContender or AbstractScheduler subclasses, using SimbaLocker, integrating Simba with Spring Boot, or writing tests for Simba-based code. Also trigger on questions about choosing between Simba backends, TTL/transition tuning, or distributed lock patterns.
+description: Guide for using the Simba distributed mutex and leader-election library in JVM projects. Use when creating distributed locks, implementing leader-only work, configuring Simba backends (JDBC/MySQL, Redis, Zookeeper), writing MutexContender or AbstractScheduler subclasses, using SimbaLocker, integrating Simba with Spring Boot, choosing backends, or tuning TTL/transition settings. For test-focused work, use the simba-testing skill as well.
 ---
 
 # Simba — Distributed Mutex Library
 
 Simba provides distributed mutex (leader election) for JVM applications with three pluggable backends: JDBC/MySQL, Redis (Spring Data Redis), and Zookeeper (Apache Curator).
+
+## How to Use This Skill
+
+Start by identifying four things:
+1. Which backend the project already runs: Redis, JDBC/MySQL, or Zookeeper.
+2. Which usage pattern fits the job: `MutexContender`, `SimbaLocker`, or `AbstractScheduler`.
+3. Who owns lifecycle: explicit `start()`/`stop()`, Kotlin `.use {}`, Java try-with-resources, or Spring `SmartLifecycle`.
+4. Whether the task is usage/configuration work or test work. For test-heavy tasks, also use `simba-testing`.
+
+Read `references/backend-internals.md` only when debugging backend behavior, explaining Lua/SQL/Curator internals, or tuning failure and handoff semantics.
 
 ## Backend Selection
 
@@ -27,7 +37,7 @@ For **Redis**:
 ```kotlin
 implementation("me.ahoo.simba:simba-spring-boot-starter") {
     capabilities {
-        requireCapability("me.ahoo.simba:simba-spring-redis-support")
+        requireCapability("me.ahoo.simba:spring-redis-support")
     }
 }
 ```
@@ -36,7 +46,7 @@ For **JDBC**:
 ```kotlin
 implementation("me.ahoo.simba:simba-spring-boot-starter") {
     capabilities {
-        requireCapability("me.ahoo.simba:simba-jdbc-support")
+        requireCapability("me.ahoo.simba:jdbc-support")
     }
 }
 ```
@@ -45,7 +55,7 @@ For **Zookeeper**:
 ```kotlin
 implementation("me.ahoo.simba:simba-spring-boot-starter") {
     capabilities {
-        requireCapability("me.ahoo.simba:simba-zookeeper-support")
+        requireCapability("me.ahoo.simba:zookeeper-support")
     }
 }
 ```
@@ -93,7 +103,7 @@ contendService.stop()
 ```
 
 Key points to explain:
-- `mutex` is the logical lock name — all contenders for the same mutex compete for one lock.
+- `mutex` is the logical lock name. All contenders for the same mutex compete for one lock.
 - `contenderId` defaults to `"{counter}:{pid}@{hostAddress}"` via `ContenderIdGenerator.HOST`. Override to use `ContenderIdGenerator.UUID` or a custom ID.
 - `onAcquired` / `onReleased` are called asynchronously on the `handleExecutor`. Don't block these callbacks.
 - The service must be started with `start()` and stopped with `stop()` when done.
@@ -129,7 +139,7 @@ Key points:
 - `acquire(timeout)` blocks the current thread until the lock is acquired or timeout expires (throws `TimeoutException`).
 - `acquire()` blocks indefinitely.
 - `close()` releases the lock. Always use try-with-resources / `.use {}` to guarantee release.
-- Internally creates a `MutexContendService` — the thread parks until `onAcquired` fires.
+- Internally creates a `MutexContendService`; the thread parks until `onAcquired` fires.
 
 ### Pattern 3: AbstractScheduler (leader-only periodic task)
 
@@ -208,7 +218,7 @@ simba:
     enabled: true                  # enable Zookeeper backend (default: true)
 ```
 
-Only enable ONE backend at a time. If multiple are on the classpath, Spring will create multiple `MutexContendServiceFactory` beans — use `@Primary` or `@Qualifier` to disambiguate.
+Prefer one backend capability and one enabled backend per application. If multiple backend modules are on the classpath and enabled, Spring can expose multiple `MutexContendServiceFactory` beans; use `@Primary` or `@Qualifier` only when that ambiguity is intentional.
 
 ### TTL and Transition Tuning
 
@@ -230,34 +240,12 @@ The JDBC backend requires a `simba_mutex` table. Provide the init script at:
 
 Requires a `DataSource` bean in the Spring context.
 
-## Writing Tests
+## Testing Pointer
 
-Tests for Simba-based code should use the TCK base classes from `simba-test`. The main test class is `MutexContendServiceSpec` which verifies:
-
-1. `start()` — acquire and release lifecycle
-2. `restart()` — stop and restart works correctly
-3. `guard()` — owner renews before TTL expires
-4. `multiContend()` — 10 contenders, exactly one owner at any time
-5. `schedule()` — AbstractScheduler lifecycle
-
-To test a new backend, extend `MutexContendServiceSpec`:
-```kotlin
-import me.ahoo.simba.core.MutexContendServiceFactory
-import me.ahoo.simba.test.MutexContendServiceSpec
-
-class MyBackendMutexContendServiceTest : MutexContendServiceSpec() {
-    override val mutexContendServiceFactory: MutexContendServiceFactory = // create your factory
-}
-```
-
-For application-level tests that use Simba, mock the `MutexContendServiceFactory` with MockK:
-```kotlin
-val mockFactory = mockk<MutexContendServiceFactory>()
-val mockService = mockk<MutexContendService>(relaxed = true)
-every { mockFactory.createMutexContendService(any()) } returns mockService
-```
-
-Use `fluent-assert` for assertions: `import me.ahoo.test.asserts.assert` and use `.assert()` extension.
+For tests, use the `simba-testing` skill. In short:
+- Application code usually mocks `MutexContendServiceFactory` and captures the created `MutexContender`.
+- Backend implementations should extend `simba-test`'s `MutexContendServiceSpec`.
+- New Kotlin assertions should use `import me.ahoo.test.asserts.assert` and the `.assert()` extension.
 
 ## Common Pitfalls
 

--- a/skills/simba/agents/openai.yaml
+++ b/skills/simba/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Simba"
+  short_description: "Use Simba distributed locks"
+  default_prompt: "Use $simba to configure Redis-backed leader election in a Spring Boot service."

--- a/skills/simba/references/backend-internals.md
+++ b/skills/simba/references/backend-internals.md
@@ -1,5 +1,7 @@
 # Backend Internals Reference
 
+Use this reference for backend debugging, not for everyday Simba usage. It mirrors the current repository implementation; when backend source changes, update this file in the same change.
+
 ## Redis Backend — Lua Scripts
 
 The Redis backend uses three Lua scripts for atomicity. Understanding these helps with debugging and tuning.
@@ -7,17 +9,17 @@ The Redis backend uses three Lua scripts for atomicity. Understanding these help
 ### mutex_acquire.lua
 
 Atomically tries to acquire the lock:
-1. `SET key contenderId NX PX transition` — set only if not exists, with millisecond expiry.
-2. On success: publishes `acquired@@contenderId` on the mutex channel, returns `contenderId@@transitionMs`.
-3. On failure (lock exists): adds contender to a sorted set wait queue (`ZADD NX score=timestamp`), returns current owner info.
+1. `SET key contenderId NX PX (ttl + transition)` - set only if not exists, with millisecond expiry.
+2. On success: publishes `acquired@@contenderId` on the mutex channel and returns `contenderId@@remainingMs`.
+3. On failure (lock exists): adds the contender to a sorted-set wait queue (`ZADD NX score=redisTimeSeconds`) and returns `currentOwnerId@@remainingPttl`.
 
-The sorted set acts as a FIFO queue — contenders are notified via Pub/Sub when the lock is released.
+The sorted set acts as the wait queue. Contenders are notified via Pub/Sub when the lock is released.
 
 ### mutex_guard.lua
 
 For the current owner to renew (extend TTL):
 1. Checks if the lock is held by this contender (`GET key == contenderId`).
-2. If yes: `SET XX PX transition` to extend the expiry. Returns success.
+2. If yes: `SET XX PX ttlMs` to extend the expiry. Returns `contenderId@@ttlMs`.
 3. If no: returns the current owner info so the contender knows it lost the lock.
 
 ### mutex_release.lua
@@ -25,7 +27,7 @@ For the current owner to renew (extend TTL):
 Releases the lock and wakes the next contender:
 1. If lock is held by this contender: `DEL key`.
 2. Picks the oldest contender from the sorted set (`ZREVRANGE -1 -1`), removes it.
-3. Publishes `released@@nextContenderId` on the contender's personal channel to wake them up.
+3. Publishes `released@@releasedOwnerId` on the next contender's personal channel to wake it up.
 
 ### Pub/Sub Channels
 
@@ -44,14 +46,13 @@ The `simba_mutex` table:
 
 ```sql
 CREATE TABLE simba_mutex (
-    mutex VARCHAR(127) NOT NULL PRIMARY KEY COMMENT 'mutex name',
-    owner_id VARCHAR(255) NOT NULL DEFAULT '' COMMENT 'current owner contender ID',
-    ttl_at BIGINT NOT NULL DEFAULT 0 COMMENT 'TTL expiry timestamp (ms)',
-    transition_at BIGINT NOT NULL DEFAULT 0 COMMENT 'transition/grace period expiry (ms)',
-    version BIGINT NOT NULL DEFAULT 0 COMMENT 'optimistic lock version',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) COMMENT='Simba distributed mutex table';
+    mutex varchar(66) not null primary key comment 'mutex name',
+    acquired_at bigint unsigned not null,
+    ttl_at bigint unsigned not null,
+    transition_at bigint unsigned not null,
+    owner_id char(32) not null,
+    version int unsigned not null
+);
 ```
 
 ### Acquire Logic (SQL CAS)
@@ -61,8 +62,9 @@ The critical `acquire` SQL atomically updates ownership:
 ```sql
 UPDATE simba_mutex
 SET owner_id = #{contenderId},
-    ttl_at = #{ttlAt},
-    transition_at = #{transitionAt},
+    acquired_at = currentDbAt,
+    ttl_at = currentDbAt + #{ttlMs},
+    transition_at = currentDbAt + #{ttlMs} + #{transitionMs},
     version = version + 1
 WHERE mutex = #{mutex}
   AND (
@@ -74,8 +76,8 @@ WHERE mutex = #{mutex}
 This ensures:
 - A new contender can only acquire if `transition_at` has passed (hard expiry).
 - The current owner can renew if still within the transition window (soft renewal).
-- `version` column prevents lost updates under concurrent access.
-- `currentDbAt` comes from `SELECT NOW()` on the DB server to avoid application-node clock skew.
+- `version` records ownership changes and helps inspect concurrent updates.
+- `currentDbAt` comes from MySQL `current_timestamp(3)` to avoid application-node clock skew.
 
 ## Zookeeper Backend — Curator Integration
 


### PR DESCRIPTION
## Summary
- add platform-neutral `skills/plugins.json` for publishing the Simba skills plugin
- improve Simba skill guidance, backend internals reference accuracy, and test-skill guidance
- add `agents/openai.yaml` UI metadata for `simba` and `simba-testing`

## Validation
- `PYTHONPATH=/tmp/codex-pyyaml python3 /Users/ahoo/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/simba`
- `PYTHONPATH=/tmp/codex-pyyaml python3 /Users/ahoo/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/simba-testing`
- `jq . skills/plugins.json >/dev/null`
- `jq -e ' .schemaVersion == 1 and (.plugins | length == 1) and (.plugins[0].skills.include == ["*"]) and (.plugins[0].skills.exclude == ["*-workspace"]) ' skills/plugins.json`\n- `PYTHONPATH=/tmp/codex-pyyaml python3` validation for `agents/openai.yaml` prompts and short descriptions\n- `rg` check for stale Simba capability names\n- `git diff --check`\n\nNo Gradle test run was needed because this PR only changes skill documentation and metadata.