### PR TITLE
chore: expand gitignore for build, out, logs, and ide metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,17 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+
+# Build outputs (per-module)
+**/build/
+**/out/
+
+# Local logs
+logs/
+
+# IDE metadata
+.idea/
+.kotlin/
+
+# OS
+.DS_Store


### PR DESCRIPTION
补充 `.gitignore` 规则，覆盖各模块构建产物、本地日志与 IDE 元数据，与 AGENTS.md 中 "Ignore local `.idea/`, `build/`, `out/`, and `logs/`" 的约定保持一致。

新增规则：
- `**/build/` / `**/out/`：通配各子模块构建产物（原规则仅覆盖根 `/build/`）
- `logs/`：本地日志
- `.idea/` / `.kotlin/`：IDE 元数据
- `.DS_Store`：macOS 系统文件

验证：修改前 28 个未跟踪条目，修改后全部被忽略。