### PR TITLE
test(core): improve simba-core unit test coverage

### DIFF
--- a/docs/superpowers/plans/2026-07-07-simba-core-test-coverage.md
+++ b/docs/superpowers/plans/2026-07-07-simba-core-test-coverage.md
@@ -1,0 +1,1891 @@
+# simba-core Test Coverage Improvement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise `simba-core` direct unit-test coverage from ~80%/weak-branch to ~95%+ line with comprehensive branch coverage by adding 13 focused unit test files — no external services required.
+
+**Architecture:** Pure JUnit Jupiter + Hamcrest unit tests mirroring the existing `ContendPeriodTest` style. A shared `TestDoubles.kt` provides deterministic fakes (`FixedClockOwner`, `FakeMutexContender`, `FakeMutexContendService`, `FakeContendServiceFactory`) used across tests — fakes over mocks, matching the TCK convention. A synchronous `Executor` makes async `notifyOwner` logic deterministic; `SimbaLocker`/`AbstractScheduler` concurrency paths use `CountDownLatch` awaitability with `finally` cleanup.
+
+**Tech Stack:** Kotlin 2.3.20 / JDK 17, JUnit Jupiter 6.1.1, Hamcrest 3.0, MockK 1.14.11 (available but unused — fakes preferred), Logback test runtime. All deps already on `simba-core` test classpath via root `configure(libraryProjects)`.
+
+---
+
+## File Structure
+
+All paths under `/Users/ahoo/work/ahoo-git/Simba/simba-core/src/test/kotlin/me/ahoo/simba/`.
+
+| File | Responsibility |
+|---|---|
+| `core/TestDoubles.kt` | Shared deterministic fakes: `FixedClockOwner`, `FakeMutexContender`, `FakeMutexContendService`, `FakeContendServiceFactory` |
+| `core/MutexStateTest.kt` | `MutexState` predicate branch combos + data-class contract |
+| `core/MutexOwnerTest.kt` | `MutexOwner` time-boundary predicates + `NONE` constant |
+| `core/ContendPeriodTest.kt` (modify) | Extend with `ensureNextDelay`/`nextDelay`/`nextContenderDelay` branch tests; use shared `FixedClockOwner` |
+| `core/AbstractMutexContenderTest.kt` | Constructor `require` validation + default contenderId + onAcquired/onReleased |
+| `core/MutexContenderTest.kt` | Default `notifyOwner` dispatch (4 branches) |
+| `core/MutexRetrievalServiceTest.kt` | `Status.isActive` all 4 states + `hasOwner` identity |
+| `core/AbstractMutexRetrievalServiceTest.kt` | Lifecycle state machine: CAS guards, try/catch rollback, `safeNotifyOwner` swallow, `close` |
+| `core/ContenderIdGeneratorTest.kt` | UUID/HOST format + counter + companion identity |
+| `locker/SimbaLockerTest.kt` | `acquire`/`acquire(timeout)` CAS + timeout + park/unpark + close |
+| `schedule/ScheduleConfigTest.kt` | `rate`/`delay` factories + enum + data-class |
+| `schedule/AbstractSchedulerTest.kt` | onAcquired guard, strategy branch, onReleased cancel, safeWork swallow |
+| `util/ThreadsTest.kt` | Thread name format + daemon=false |
+| `SimbaTest.kt` | Brand constants |
+| `SimbaExceptionTest.kt` | 5 constructors + RuntimeException inheritance |
+
+**Ordering rationale:** `TestDoubles.kt` first (everything depends on it), then leaf value types (`MutexState`, `MutexOwner`, `ContendPeriod`) with no dependencies, then contender/retrieval interfaces, then the state machine (uses fakes), then the high-level `SimbaLocker`/`AbstractScheduler` (use fakes), finally trivial constants/utilities.
+
+**No production code changes. No `build.gradle.kts` changes.**
+
+---
+
+## Task 1: Shared TestDoubles
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt`
+
+- [ ] **Step 1: Create TestDoubles.kt with shared fakes**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import java.util.concurrent.Executor
+
+/**
+ * [MutexOwner] with a fixed [currentAt] for deterministic time-based tests.
+ */
+class FixedClockOwner(
+    ownerId: String,
+    ttlAt: Long,
+    transitionAt: Long,
+    private val fixedCurrentAt: Long
+) : MutexOwner(ownerId = ownerId, acquiredAt = 0, ttlAt = ttlAt, transitionAt = transitionAt) {
+    override val currentAt: Long
+        get() = fixedCurrentAt
+}
+
+/**
+ * [MutexContender] that records [onAcquired]/[onReleased] calls.
+ * Inherits the default [notifyOwner] dispatch from [MutexContender].
+ */
+class FakeMutexContender(
+    override val mutex: String,
+    override val contenderId: String
+) : MutexContender {
+    val acquired = mutableListOf<MutexState>()
+    val released = mutableListOf<MutexState>()
+
+    var throwOnNotify: Throwable? = null
+
+    override fun notifyOwner(mutexState: MutexState) {
+        throwOnNotify?.let { throw it }
+        super.notifyOwner(mutexState)
+    }
+
+    override fun onAcquired(mutexState: MutexState) {
+        acquired += mutexState
+    }
+
+    override fun onReleased(mutexState: MutexState) {
+        released += mutexState
+    }
+}
+
+/**
+ * Synchronous executor that runs tasks inline on the calling thread.
+ */
+object SameThreadExecutor : Executor {
+    override fun execute(command: Runnable) {
+        command.run()
+    }
+}
+
+/**
+ * [AbstractMutexContendService] fake with controllable start/stop/notify behavior.
+ * Uses [SameThreadExecutor] by default so [notifyOwner] runs inline.
+ */
+class FakeMutexContendService(
+    contender: MutexContender,
+    handleExecutor: Executor = SameThreadExecutor,
+    var throwOnStartContend: Throwable? = null,
+    var throwOnStopContend: Throwable? = null
+) : AbstractMutexContendService(contender, handleExecutor) {
+    var startContendCalled = false
+        private set
+    var stopContendCalled = false
+        private set
+
+    override fun startContend() {
+        startContendCalled = true
+        throwOnStartContend?.let { throw it }
+    }
+
+    override fun stopContend() {
+        stopContendCalled = true
+        throwOnStopContend?.let { throw it }
+    }
+
+    /** Exposes the protected [notifyOwner] for tests. */
+    fun publishOwner(newOwner: MutexOwner) {
+        notifyOwner(newOwner)
+    }
+}
+
+/**
+ * [MutexContendServiceFactory] that returns a preconfigured service.
+ */
+class FakeContendServiceFactory(private val service: MutexContendService) : MutexContendServiceFactory {
+    override fun createMutexContendService(mutexContender: MutexContender): MutexContendService {
+        return service
+    }
+}
+```
+
+- [ ] **Step 2: Compile to verify fakes are well-formed**
+
+Run: `./gradlew simba-core:compileTestKotlin`
+Expected: BUILD SUCCESSFUL (no tests run yet, just compilation).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt
+git commit -m "test(core): add shared test doubles for simba-core unit tests"
+```
+
+---
+
+## Task 2: MutexStateTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/core/MutexStateTest.kt`
+
+- [ ] **Step 1: Write MutexStateTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+
+class MutexStateTest {
+    private val ownerA = MutexOwner("A", 0, 100, 200)
+    private val ownerB = MutexOwner("B", 0, 100, 200)
+
+    @Test
+    fun `isChanged is false when before and after share ownerId`() {
+        assertThat(MutexState(ownerA, ownerA).isChanged, equalTo(false))
+    }
+
+    @Test
+    fun `isChanged is false for NONE`() {
+        assertThat(MutexState.NONE.isChanged, equalTo(false))
+    }
+
+    @Test
+    fun `isChanged is true when owners differ`() {
+        assertThat(MutexState(ownerA, ownerB).isChanged, equalTo(true))
+    }
+
+    @Test
+    fun `isAcquired is true when changed and after owns`() {
+        assertThat(MutexState(ownerA, ownerB).isAcquired("B"), equalTo(true))
+    }
+
+    @Test
+    fun `isAcquired is false when unchanged even if after owns`() {
+        assertThat(MutexState(ownerB, ownerB).isAcquired("B"), equalTo(false))
+    }
+
+    @Test
+    fun `isAcquired is false when changed but after does not own`() {
+        assertThat(MutexState(ownerA, ownerB).isAcquired("A"), equalTo(false))
+    }
+
+    @Test
+    fun `isReleased is true when changed and before owns`() {
+        assertThat(MutexState(ownerA, ownerB).isReleased("A"), equalTo(true))
+    }
+
+    @Test
+    fun `isReleased is false when unchanged`() {
+        assertThat(MutexState(ownerA, ownerA).isReleased("A"), equalTo(false))
+    }
+
+    @Test
+    fun `isReleased is false when changed but before does not own`() {
+        assertThat(MutexState(ownerA, ownerB).isReleased("B"), equalTo(false))
+    }
+
+    @Test
+    fun `isOwner delegates to after owner`() {
+        assertThat(MutexState(ownerA, ownerB).isOwner("B"), equalTo(true))
+        assertThat(MutexState(ownerA, ownerB).isOwner("A"), equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl is true when owner and after in ttl`() {
+        val inTtl = FixedClockOwner("B", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(MutexState(ownerA, inTtl).isInTtl("B"), equalTo(true))
+    }
+
+    @Test
+    fun `isInTtl is false when owner but after expired`() {
+        val expired = FixedClockOwner("B", ttlAt = 50, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(MutexState(ownerA, expired).isInTtl("B"), equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl is false when not owner`() {
+        val inTtl = FixedClockOwner("B", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(MutexState(ownerA, inTtl).isInTtl("A"), equalTo(false))
+    }
+
+    @Test
+    fun `data class equals and copy`() {
+        val state = MutexState(ownerA, ownerB)
+        val copy = state.copy()
+        assertThat(copy, equalTo(state))
+        assertThat(copy, not(sameInstance(state)))
+    }
+
+    @Test
+    fun `data class component destructuring`() {
+        val (before, after) = MutexState(ownerA, ownerB)
+        assertThat(before, equalTo(ownerA))
+        assertThat(after, equalTo(ownerB))
+    }
+
+    @Test
+    fun `NONE equals state of two NONE owners`() {
+        assertThat(MutexState.NONE, equalTo(MutexState(MutexOwner.NONE, MutexOwner.NONE)))
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.core.MutexStateTest"`
+Expected: PASS (all tests green).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/core/MutexStateTest.kt
+git commit -m "test(core): add MutexState predicate branch tests"
+```
+
+---
+
+## Task 3: MutexOwnerTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/core/MutexOwnerTest.kt`
+
+- [ ] **Step 1: Write MutexOwnerTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+class MutexOwnerTest {
+    @Test
+    fun `isOwner returns true when ids match`() {
+        val owner = MutexOwner("A", 0, 100, 200)
+        assertThat(owner.isOwner("A"), equalTo(true))
+    }
+
+    @Test
+    fun `isOwner returns false when ids differ`() {
+        val owner = MutexOwner("A", 0, 100, 200)
+        assertThat(owner.isOwner("B"), equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl is true when ttlAt greater than currentAt`() {
+        val owner = FixedClockOwner("A", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl, equalTo(true))
+    }
+
+    @Test
+    fun `isInTtl is false when ttlAt equals currentAt`() {
+        val owner = FixedClockOwner("A", ttlAt = 100, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl, equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl is false when ttlAt less than currentAt`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl, equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl contenderId is true for owner in ttl`() {
+        val owner = FixedClockOwner("A", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl("A"), equalTo(true))
+    }
+
+    @Test
+    fun `isInTtl contenderId is false for owner expired`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl("A"), equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl contenderId is false for non owner even if in ttl`() {
+        val owner = FixedClockOwner("A", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl("B"), equalTo(false))
+    }
+
+    @Test
+    fun `isInTransition is true at equality boundary`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 100, fixedCurrentAt = 100)
+        assertThat(owner.isInTransition, equalTo(true))
+    }
+
+    @Test
+    fun `isInTransition is false when transitionAt less than currentAt`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 50, fixedCurrentAt = 100)
+        assertThat(owner.isInTransition, equalTo(false))
+    }
+
+    @Test
+    fun `isInTransitionOf is true for owner in transition`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 200, fixedCurrentAt = 100)
+        assertThat(owner.isInTransitionOf("A"), equalTo(true))
+    }
+
+    @Test
+    fun `isInTransitionOf is false for non owner`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 200, fixedCurrentAt = 100)
+        assertThat(owner.isInTransitionOf("B"), equalTo(false))
+    }
+
+    @Test
+    fun `hasOwner is true at transition boundary`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 100, fixedCurrentAt = 100)
+        assertThat(owner.hasOwner(), equalTo(true))
+    }
+
+    @Test
+    fun `hasOwner is false when transitionAt less than currentAt`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 50, fixedCurrentAt = 100)
+        assertThat(owner.hasOwner(), equalTo(false))
+    }
+
+    @Test
+    fun `default args yield inTtl and inTransition true`() {
+        val owner = MutexOwner("A")
+        assertThat(owner.isInTtl, equalTo(true))
+        assertThat(owner.isInTransition, equalTo(true))
+        assertThat(owner.hasOwner(), equalTo(true))
+    }
+
+    @Test
+    fun `NONE constant has empty ownerId and is expired`() {
+        assertThat(MutexOwner.NONE.ownerId, equalTo(MutexOwner.NONE_OWNER_ID))
+        assertThat(MutexOwner.NONE_OWNER_ID, equalTo(""))
+        assertThat(MutexOwner.NONE.isInTtl, equalTo(false))
+        assertThat(MutexOwner.NONE.isInTransition, equalTo(false))
+        assertThat(MutexOwner.NONE.hasOwner(), equalTo(false))
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.core.MutexOwnerTest"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/core/MutexOwnerTest.kt
+git commit -m "test(core): add MutexOwner time-boundary predicate tests"
+```
+
+---
+
+## Task 4: Extend ContendPeriodTest
+
+**Files:**
+- Modify: `simba-core/src/test/kotlin/me/ahoo/simba/core/ContendPeriodTest.kt`
+
+- [ ] **Step 1: Replace ContendPeriodTest with extended version using shared FixedClockOwner**
+
+Replace the entire file content with:
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.greaterThanOrEqualTo
+import org.hamcrest.Matchers.lessThan
+import org.junit.jupiter.api.Test
+
+class ContendPeriodTest {
+    @Test
+    fun `owner delay uses owner clock`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 1400,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+
+        assertThat(ContendPeriod.nextOwnerDelay(owner), equalTo(400))
+    }
+
+    @Test
+    fun `ensureNextDelay clamps negative delay to zero`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 500,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+        val period = ContendPeriod("owner")
+
+        assertThat(period.ensureNextDelay(owner), equalTo(0L))
+    }
+
+    @Test
+    fun `ensureNextDelay returns computed delay when positive`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 1400,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+        val period = ContendPeriod("owner")
+
+        assertThat(period.ensureNextDelay(owner), equalTo(400L))
+    }
+
+    @Test
+    fun `nextDelay delegates to owner delay when contender is owner`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 1400,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+        val period = ContendPeriod("owner")
+
+        assertThat(period.nextDelay(owner), equalTo(ContendPeriod.nextOwnerDelay(owner)))
+    }
+
+    @Test
+    fun `nextDelay delegates to contender delay when contender is not owner`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 1400,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+        val period = ContendPeriod("other")
+
+        assertThat(period.nextDelay(owner), equalTo(ContendPeriod.nextContenderDelay(owner)))
+    }
+
+    @Test
+    fun `nextContenderDelay with zero transition stays in non-negative range`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 2000,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+
+        val delay = ContendPeriod.nextContenderDelay(owner)
+
+        assertThat(delay, greaterThanOrEqualTo(1000L))
+        assertThat(delay, lessThan(2000L))
+    }
+
+    @Test
+    fun `nextContenderDelay with non-zero transition allows negative offset`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 1400,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+
+        val delay = ContendPeriod.nextContenderDelay(owner)
+
+        assertThat(delay, greaterThanOrEqualTo(800L))
+        assertThat(delay, lessThan(2000L))
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.core.ContendPeriodTest"`
+Expected: PASS (original test still green + new tests green).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/core/ContendPeriodTest.kt
+git commit -m "test(core): extend ContendPeriodTest with branch coverage"
+```
+
+---
+
+## Task 5: AbstractMutexContenderTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexContenderTest.kt`
+
+- [ ] **Step 1: Write AbstractMutexContenderTest**
+
+Note: the host-format regex uses Hamcrest's `matchesPattern(String)`, which treats the string as a regex — so `\d` matches digits. Do not use `Regex.fromLiteral` (it escapes the pattern).
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.blankOrNullString
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.matchesPattern
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AbstractMutexContenderTest {
+    private fun newContender(mutex: String, contenderId: String = "c1"): AbstractMutexContender {
+        return object : AbstractMutexContender(mutex, contenderId) {}
+    }
+
+    @Test
+    fun `rejects blank mutex`() {
+        val error = assertThrows<IllegalArgumentException> { newContender("") }
+        assertThat(error.message, equalTo("mutex must not be blank!"))
+    }
+
+    @Test
+    fun `rejects whitespace-only mutex`() {
+        val error = assertThrows<IllegalArgumentException> { newContender("   ") }
+        assertThat(error.message, equalTo("mutex must not be blank!"))
+    }
+
+    @Test
+    fun `rejects blank contenderId`() {
+        val error = assertThrows<IllegalArgumentException> { newContender("m", "") }
+        assertThat(error.message, equalTo("contenderId must not be blank!"))
+    }
+
+    @Test
+    fun `rejects whitespace-only contenderId`() {
+        val error = assertThrows<IllegalArgumentException> { newContender("m", "  ") }
+        assertThat(error.message, equalTo("contenderId must not be blank!"))
+    }
+
+    @Test
+    fun `default contenderId is generated host format`() {
+        val contender = object : AbstractMutexContender("m") {}
+        assertThat(contender.contenderId, not(blankOrNullString()))
+        assertThat(
+            contender.contenderId,
+            matchesPattern("\\d+:\\d+@.+")
+        )
+    }
+
+    @Test
+    fun `onAcquired and onReleased do not throw`() {
+        val contender = newContender("m", "c1")
+        val state = MutexState(MutexOwner.NONE, MutexOwner("c1", 0, 100, 200))
+
+        contender.onAcquired(state)
+        contender.onReleased(state)
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.core.AbstractMutexContenderTest"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexContenderTest.kt
+git commit -m "test(core): add AbstractMutexContender validation tests"
+```
+
+---
+
+## Task 6: MutexContenderTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/core/MutexContenderTest.kt`
+
+- [ ] **Step 1: Write MutexContenderTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+class MutexContenderTest {
+    private val ownerA = MutexOwner("A", 0, 100, 200)
+    private val ownerB = MutexOwner("B", 0, 100, 200)
+
+    @Test
+    fun `notifyOwner skips callbacks when state unchanged`() {
+        val contender = FakeMutexContender("m", "A")
+
+        contender.notifyOwner(MutexState(ownerA, ownerA))
+
+        assertThat(contender.acquired.size, equalTo(0))
+        assertThat(contender.released.size, equalTo(0))
+    }
+
+    @Test
+    fun `notifyOwner fires onAcquired when contender becomes owner`() {
+        val contender = FakeMutexContender("m", "B")
+
+        contender.notifyOwner(MutexState(ownerA, ownerB))
+
+        assertThat(contender.acquired.size, equalTo(1))
+        assertThat(contender.released.size, equalTo(0))
+    }
+
+    @Test
+    fun `notifyOwner fires onReleased when contender loses ownership`() {
+        val contender = FakeMutexContender("m", "A")
+
+        contender.notifyOwner(MutexState(ownerA, ownerB))
+
+        assertThat(contender.acquired.size, equalTo(0))
+        assertThat(contender.released.size, equalTo(1))
+    }
+
+    @Test
+    fun `notifyOwner fires only onAcquired for the new owner on role swap`() {
+        val newOwner = FakeMutexContender("m", "B")
+
+        newOwner.notifyOwner(MutexState(ownerA, ownerB))
+
+        assertThat(newOwner.acquired.size, equalTo(1))
+        assertThat(newOwner.released.size, equalTo(0))
+    }
+
+    @Test
+    fun `notifyOwner fires only onReleased for the previous owner on role swap`() {
+        val previousOwner = FakeMutexContender("m", "A")
+
+        previousOwner.notifyOwner(MutexState(ownerA, ownerB))
+
+        assertThat(previousOwner.acquired.size, equalTo(0))
+        assertThat(previousOwner.released.size, equalTo(1))
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.core.MutexContenderTest"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/core/MutexContenderTest.kt
+git commit -m "test(core): add MutexContender default notifyOwner dispatch tests"
+```
+
+---
+
+## Task 7: MutexRetrievalServiceTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/core/MutexRetrievalServiceTest.kt`
+
+- [ ] **Step 1: Write MutexRetrievalServiceTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+class MutexRetrievalServiceTest {
+    @Test
+    fun `Status INITIAL is not active`() {
+        assertThat(MutexRetrievalService.Status.INITIAL.isActive, equalTo(false))
+    }
+
+    @Test
+    fun `Status STARTING is active`() {
+        assertThat(MutexRetrievalService.Status.STARTING.isActive, equalTo(true))
+    }
+
+    @Test
+    fun `Status RUNNING is active`() {
+        assertThat(MutexRetrievalService.Status.RUNNING.isActive, equalTo(true))
+    }
+
+    @Test
+    fun `Status STOPPING is not active`() {
+        assertThat(MutexRetrievalService.Status.STOPPING.isActive, equalTo(false))
+    }
+
+    @Test
+    fun `hasOwner is false when afterOwner is NONE by identity`() {
+        val service = FakeMutexContendService(FakeMutexContender("m", "c1"))
+        // mutexState defaults to MutexState.NONE -> afterOwner is MutexOwner.NONE
+        assertThat(service.hasOwner(), equalTo(false))
+    }
+
+    @Test
+    fun `hasOwner is true when afterOwner is a real owner`() {
+        val contender = FakeMutexContender("m", "c1")
+        val service = FakeMutexContendService(contender)
+        service.start()
+
+        service.publishOwner(MutexOwner("c1", 0, 100, 200))
+
+        assertThat(service.hasOwner(), equalTo(true))
+        service.stop()
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.core.MutexRetrievalServiceTest"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/core/MutexRetrievalServiceTest.kt
+git commit -m "test(core): add MutexRetrievalService Status and hasOwner tests"
+```
+
+---
+
+## Task 8: AbstractMutexRetrievalServiceTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt`
+
+- [ ] **Step 1: Write AbstractMutexRetrievalServiceTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AbstractMutexRetrievalServiceTest {
+    private fun newService(): FakeMutexContendService {
+        val contender = FakeMutexContender("m", "c1")
+        return FakeMutexContendService(contender)
+    }
+
+    @Test
+    fun `start transitions INITIAL to RUNNING and calls startContend`() {
+        val service = newService()
+
+        service.start()
+
+        assertThat(service.status, equalTo(MutexRetrievalService.Status.RUNNING))
+        assertThat(service.startContendCalled, equalTo(true))
+        service.stop()
+    }
+
+    @Test
+    fun `start from RUNNING throws IllegalStateException`() {
+        val service = newService()
+        service.start()
+
+        val error = assertThrows<IllegalStateException> { service.start() }
+        assertThat(error.message, equalTo("Cannot start from state [RUNNING]. Expected: [INITIAL]"))
+
+        service.stop()
+    }
+
+    @Test
+    fun `start rollback to INITIAL when startContend throws`() {
+        val service = newService()
+        service.throwOnStartContend = IllegalStateException("boom")
+
+        val error = assertThrows<IllegalStateException> { service.start() }
+
+        assertThat(error.message, equalTo("boom"))
+        assertThat(service.status, equalTo(MutexRetrievalService.Status.INITIAL))
+    }
+
+    @Test
+    fun `stop transitions RUNNING to INITIAL and calls stopContend`() {
+        val service = newService()
+        service.start()
+
+        service.stop()
+
+        assertThat(service.status, equalTo(MutexRetrievalService.Status.INITIAL))
+        assertThat(service.stopContendCalled, equalTo(true))
+    }
+
+    @Test
+    fun `stop from INITIAL throws IllegalStateException`() {
+        val service = newService()
+
+        val error = assertThrows<IllegalStateException> { service.stop() }
+        assertThat(error.message, equalTo("Cannot stop mutex:[m] from state:[INITIAL]. Expected:[RUNNING]"))
+    }
+
+    @Test
+    fun `stop resets to INITIAL even when stopContend throws`() {
+        val service = newService()
+        service.start()
+        service.throwOnStopContend = IllegalStateException("stop-boom")
+
+        val error = assertThrows<IllegalStateException> { service.stop() }
+
+        assertThat(error.message, equalTo("stop-boom"))
+        assertThat(service.status, equalTo(MutexRetrievalService.Status.INITIAL))
+    }
+
+    @Test
+    fun `publishOwner updates mutexState and notifies retriever`() {
+        val contender = FakeMutexContender("m", "c1")
+        val service = FakeMutexContendService(contender)
+        service.start()
+        val previous = MutexOwner("other", 0, 50, 100)
+        service.publishOwner(previous)
+
+        val newOwner = MutexOwner("c1", 0, 100, 200)
+        service.publishOwner(newOwner).join()
+
+        assertThat(service.afterOwner, sameInstance(newOwner))
+        assertThat(service.beforeOwner, sameInstance(previous))
+        // contender became owner -> onAcquired fired
+        assertThat(contender.acquired.size, equalTo(1))
+        service.stop()
+    }
+
+    @Test
+    fun `publishOwner swallows retriever exception and keeps mutexState`() {
+        val contender = FakeMutexContender("m", "c1")
+        contender.throwOnNotify = IllegalStateException("notify-boom")
+        val service = FakeMutexContendService(contender)
+        service.start()
+
+        val newOwner = MutexOwner("c1", 0, 100, 200)
+        // Should not throw despite retriever.notifyOwner throwing
+        service.publishOwner(newOwner).join()
+
+        // mutexState was assigned BEFORE the throw (order-of-assignment contract)
+        assertThat(service.afterOwner, sameInstance(newOwner))
+        // no exception escaped the CompletableFuture
+        assertThat(contender.acquired.size, equalTo(0))
+        service.stop()
+    }
+
+    @Test
+    fun `close delegates to stop and throws when not running`() {
+        val service = newService()
+
+        val error = assertThrows<IllegalStateException> { service.close() }
+        assertThat(error.message, equalTo("Cannot stop mutex:[m] from state:[INITIAL]. Expected:[RUNNING]"))
+    }
+
+    @Test
+    fun `start resets owner to NONE via resetOwner`() {
+        val contender = FakeMutexContender("m", "c1")
+        val service = FakeMutexContendService(contender)
+        service.start()
+        service.publishOwner(MutexOwner("c1", 0, 100, 200)).join()
+        assertThat(service.hasOwner(), equalTo(true))
+
+        service.stop()
+        service.start()
+
+        // startRetrieval -> resetOwner -> mutexState = NONE
+        assertThat(service.mutexState, equalTo(MutexState.NONE))
+        service.stop()
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.core.AbstractMutexRetrievalServiceTest"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
+git commit -m "test(core): add AbstractMutexRetrievalService state machine tests"
+```
+
+---
+
+## Task 9: ContenderIdGeneratorTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/core/ContenderIdGeneratorTest.kt`
+
+- [ ] **Step 1: Write ContenderIdGeneratorTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.matchesPattern
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+
+class ContenderIdGeneratorTest {
+    @Test
+    fun `UUID generates 32 hex chars without dashes`() {
+        val id = UUIDContenderIdGenerator.generate()
+
+        assertThat(id.length, equalTo(32))
+        assertThat(id, matchesPattern("[0-9a-f]{32}"))
+    }
+
+    @Test
+    fun `UUID generates distinct ids`() {
+        assertThat(UUIDContenderIdGenerator.generate(), not(equalTo(UUIDContenderIdGenerator.generate())))
+    }
+
+    @Test
+    fun `HOST generates counter pid host format`() {
+        val id = HostContenderIdGenerator.generate()
+
+        assertThat(id, matchesPattern("\\d+:\\d+@.+"))
+    }
+
+    @Test
+    fun `HOST increments counter across calls`() {
+        val first = HostContenderIdGenerator.generate()
+        val second = HostContenderIdGenerator.generate()
+
+        val firstCounter = first.substringBefore(":").toLong()
+        val secondCounter = second.substringBefore(":").toLong()
+        assertThat(secondCounter, equalTo(firstCounter + 1L))
+    }
+
+    @Test
+    fun `companion UUID field is the singleton instance`() {
+        assertThat(ContenderIdGenerator.UUID, sameInstance(UUIDContenderIdGenerator))
+    }
+
+    @Test
+    fun `companion HOST field is the singleton instance`() {
+        assertThat(ContenderIdGenerator.HOST, sameInstance(HostContenderIdGenerator))
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.core.ContenderIdGeneratorTest"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/core/ContenderIdGeneratorTest.kt
+git commit -m "test(core): add ContenderIdGenerator UUID and HOST tests"
+```
+
+---
+
+## Task 10: SimbaTest + SimbaExceptionTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/SimbaTest.kt`
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/SimbaExceptionTest.kt`
+
+- [ ] **Step 1: Write SimbaTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+class SimbaTest {
+    @Test
+    fun `SIMBA constant is simba`() {
+        assertThat(Simba.SIMBA, equalTo("simba"))
+    }
+
+    @Test
+    fun `SIMBA_PREFIX constant is simba dot`() {
+        assertThat(Simba.SIMBA_PREFIX, equalTo("simba."))
+    }
+}
+```
+
+- [ ] **Step 2: Write SimbaExceptionTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.instanceOf
+import org.hamcrest.Matchers.nullValue
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+
+class SimbaExceptionTest {
+    @Test
+    fun `is a RuntimeException`() {
+        assertThat(SimbaException(), instanceOf(RuntimeException::class.java))
+    }
+
+    @Test
+    fun `default constructor has null message and cause`() {
+        val ex = SimbaException()
+        assertThat(ex.message, nullValue())
+        assertThat(ex.cause, nullValue())
+    }
+
+    @Test
+    fun `message constructor sets message`() {
+        val ex = SimbaException("msg")
+        assertThat(ex.message, equalTo("msg"))
+        assertThat(ex.cause, nullValue())
+    }
+
+    @Test
+    fun `message and cause constructor sets both`() {
+        val cause = IllegalStateException("root")
+        val ex = SimbaException("msg", cause)
+        assertThat(ex.message, equalTo("msg"))
+        assertThat(ex.cause, sameInstance(cause))
+    }
+
+    @Test
+    fun `cause constructor sets cause`() {
+        val cause = IllegalStateException("root")
+        val ex = SimbaException(cause)
+        assertThat(ex.cause, sameInstance(cause))
+    }
+
+    @Test
+    fun `full constructor sets suppression and stack trace flags`() {
+        val cause = IllegalStateException("root")
+        val ex = SimbaException("msg", cause, true, false)
+
+        assertThat(ex.message, equalTo("msg"))
+        assertThat(ex.cause, sameInstance(cause))
+    }
+
+    @Test
+    fun `open class allows subclassing`() {
+        class CustomSimbaException : SimbaException("custom")
+
+        val sub = CustomSimbaException()
+        assertThat(sub, instanceOf(SimbaException::class.java))
+        assertThat(sub.message, equalTo("custom"))
+    }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.SimbaTest" --tests "me.ahoo.simba.SimbaExceptionTest"`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/SimbaTest.kt simba-core/src/test/kotlin/me/ahoo/simba/SimbaExceptionTest.kt
+git commit -m "test(core): add Simba constants and SimbaException tests"
+```
+
+---
+
+## Task 11: ThreadsTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/util/ThreadsTest.kt`
+
+- [ ] **Step 1: Write ThreadsTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.util
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+
+class ThreadsTest {
+    @Test
+    fun `defaultFactory creates non-daemon threads`() {
+        val factory = Threads.defaultFactory("domain")
+
+        val thread = factory.newThread { }
+
+        assertThat(thread.isDaemon, `is`(false))
+    }
+
+    @Test
+    fun `defaultFactory names threads with domain counter`() {
+        val factory = Threads.defaultFactory("worker")
+
+        val first = factory.newThread { }
+        val second = factory.newThread { }
+
+        assertThat(first.name, equalTo("worker-0"))
+        assertThat(second.name, equalTo("worker-1"))
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.util.ThreadsTest"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/util/ThreadsTest.kt
+git commit -m "test(core): add Threads defaultFactory tests"
+```
+
+---
+
+## Task 12: ScheduleConfigTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/schedule/ScheduleConfigTest.kt`
+
+- [ ] **Step 1: Write ScheduleConfigTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.schedule
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class ScheduleConfigTest {
+    @Test
+    fun `rate factory sets FIXED_RATE strategy`() {
+        val config = ScheduleConfig.rate(Duration.ofMillis(10), Duration.ofMillis(100))
+
+        assertThat(config.strategy, equalTo(ScheduleConfig.Strategy.FIXED_RATE))
+        assertThat(config.initialDelay, equalTo(Duration.ofMillis(10)))
+        assertThat(config.period, equalTo(Duration.ofMillis(100)))
+    }
+
+    @Test
+    fun `delay factory sets FIXED_DELAY strategy`() {
+        val config = ScheduleConfig.delay(Duration.ofMillis(10), Duration.ofMillis(100))
+
+        assertThat(config.strategy, equalTo(ScheduleConfig.Strategy.FIXED_DELAY))
+    }
+
+    @Test
+    fun `data class equals and copy`() {
+        val config = ScheduleConfig.rate(Duration.ofMillis(10), Duration.ofMillis(100))
+        val copy = config.copy()
+
+        assertThat(copy, equalTo(config))
+        assertThat(copy, not(sameInstance(config)))
+    }
+
+    @Test
+    fun `data class component destructuring`() {
+        val config = ScheduleConfig.delay(Duration.ofMillis(5), Duration.ofMillis(50))
+
+        val (strategy, initialDelay, period) = config
+        assertThat(strategy, equalTo(ScheduleConfig.Strategy.FIXED_DELAY))
+        assertThat(initialDelay, equalTo(Duration.ofMillis(5)))
+        assertThat(period, equalTo(Duration.ofMillis(50)))
+    }
+
+    @Test
+    fun `Strategy enum has FIXED_DELAY then FIXED_RATE in order`() {
+        val values = ScheduleConfig.Strategy.values()
+
+        assertThat(values.size, equalTo(2))
+        assertThat(values[0], equalTo(ScheduleConfig.Strategy.FIXED_DELAY))
+        assertThat(values[1], equalTo(ScheduleConfig.Strategy.FIXED_RATE))
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.schedule.ScheduleConfigTest"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/schedule/ScheduleConfigTest.kt
+git commit -m "test(core): add ScheduleConfig factory and enum tests"
+```
+
+---
+
+## Task 13: SimbaLockerTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt`
+
+**Design note (important):** `SimbaLocker` builds its contend service inside its own constructor via the factory. The service needs the locker (as the contender) to call `onAcquired` back. So the factory must build the service on demand using the `mutexContender` argument passed to `createMutexContendService` — that argument IS the locker. A pre-built service (like `FakeContendServiceFactory`) cannot work here because its contender is fixed before the locker exists. Use the `ControllableFactory` below which lazily creates the service and exposes it.
+
+- [ ] **Step 1: Write SimbaLockerTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.locker
+
+import me.ahoo.simba.core.AbstractMutexContendService
+import me.ahoo.simba.core.MutexContendService
+import me.ahoo.simba.core.MutexContendServiceFactory
+import me.ahoo.simba.core.MutexContender
+import me.ahoo.simba.core.MutexOwner
+import me.ahoo.simba.core.MutexState
+import me.ahoo.simba.core.SameThreadExecutor
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Controllable contend service bound to the contender passed by the factory.
+ * Tests flip ownership by calling [markOwner], which dispatches to
+ * [AbstractMutexContendService.notifyOwner] -> contender.notifyOwner.
+ */
+private class ControllableContendService(
+    contender: MutexContender
+) : AbstractMutexContendService(contender, SameThreadExecutor) {
+    override fun startContend() {}
+    override fun stopContend() {}
+
+    fun markOwner(ownerId: String) {
+        notifyOwner(MutexOwner(ownerId, 0, Long.MAX_VALUE, Long.MAX_VALUE))
+    }
+}
+
+/**
+ * Factory that builds a [ControllableContendService] for the given contender
+ * (the locker) and exposes it so tests can drive ownership transitions.
+ */
+private class ControllableFactory : MutexContendServiceFactory {
+    var service: ControllableContendService? = null
+        private set
+
+    override fun createMutexContendService(mutexContender: MutexContender): MutexContendService {
+        val svc = ControllableContendService(mutexContender)
+        service = svc
+        return svc
+    }
+}
+
+class SimbaLockerTest {
+    @Test
+    fun `acquire with timeout throws TimeoutException when ownership never acquired`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        val error = assertThrows<TimeoutException> {
+            locker.acquire(Duration.ofMillis(50))
+        }
+        assertThat(error.message, containsString("Could not acquire"))
+        assertThat(error.message, containsString("within timeout of 50ms"))
+    }
+
+    @Test
+    fun `double acquire with timeout throws IllegalMonitorStateException`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        locker.acquire(Duration.ofMillis(200))
+
+        val error = assertThrows<IllegalMonitorStateException> {
+            locker.acquire(Duration.ofMillis(50))
+        }
+        assertThat(error.message, containsString("already owns this lock"))
+    }
+
+    @Test
+    fun `acquire without timeout throws IllegalMonitorStateException on double acquire`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        // First acquire via timeout (resolves without blocking forever)
+        locker.acquire(Duration.ofMillis(200))
+
+        val error = assertThrows<IllegalMonitorStateException> {
+            locker.acquire()
+        }
+        assertThat(error.message, containsString("already owns this lock"))
+    }
+
+    @Test
+    fun `acquire returns when onAcquired unparks the calling thread`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+        val acquired = CountDownLatch(1)
+
+        // Run acquire() on a separate thread; it parks inside LockSupport.park(this).
+        // The main thread then marks ownership, which dispatches to the contender's
+        // notifyOwner -> SimbaLocker.onAcquired -> LockSupport.unpark(owner thread).
+        val ownerThread = Thread {
+            locker.acquire()
+            acquired.countDown()
+        }
+        ownerThread.isDaemon = true
+        ownerThread.start()
+
+        // Wait until the locker's contend service is created and acquire() has parked.
+        // Poll the owner thread until it is WAITING (parked) before marking ownership,
+        // so the unpark is guaranteed to find a parked thread.
+        awaitThreadState(ownerThread, Thread.State.WAITING, 2, TimeUnit.SECONDS)
+        factory.service!!.markOwner(locker.contenderId)
+
+        assertThat("acquire should return after onAcquired unparks", acquired.await(2, TimeUnit.SECONDS))
+        assertThat(ownerThread.state, equalTo(Thread.State.TERMINATED))
+    }
+
+    @Test
+    fun `onAcquired does not throw when no thread owns the locker`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        // Call onAcquired directly without a prior acquire() — OWNER[this] is null,
+        // LockSupport.unpark(null) is a safe no-op.
+        locker.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(locker.contenderId, 0, 100, 200)))
+    }
+
+    @Test
+    fun `close throws IllegalStateException when contend service not running`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        val error = assertThrows<IllegalStateException> { locker.close() }
+        assertThat(error.message, containsString("Cannot stop mutex:[m]"))
+    }
+
+    private fun awaitThreadState(
+        thread: Thread,
+        state: Thread.State,
+        timeout: Long,
+        unit: TimeUnit
+    ) {
+        val deadline = System.nanoTime() + unit.toNanos(timeout)
+        while (System.nanoTime() < deadline) {
+            if (thread.state == state) return
+            Thread.sleep(10)
+        }
+        throw AssertionError("Thread did not reach state $state within $timeout $unit (was ${thread.state})")
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.locker.SimbaLockerTest"`
+Expected: PASS. The `acquire returns when onAcquired unparks` test polls the owner thread's state until it is `WAITING` (parked) before marking ownership, avoiding the flakiness of a fixed `Thread.sleep`. The 2-second `CountDownLatch.await` is the safety net.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
+git commit -m "test(core): add SimbaLocker acquire, timeout, and unpark tests"
+```
+
+---
+
+## Task 14: AbstractSchedulerTest
+
+**Files:**
+- Create: `simba-core/src/test/kotlin/me/ahoo/simba/schedule/AbstractSchedulerTest.kt`
+
+- [ ] **Step 1: Write AbstractSchedulerTest**
+
+```kotlin
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.schedule
+
+import me.ahoo.simba.core.MutexContendServiceFactory
+import me.ahoo.simba.core.MutexContender
+import me.ahoo.simba.core.MutexOwner
+import me.ahoo.simba.core.MutexState
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.greaterThanOrEqualTo
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Minimal AbstractScheduler subclass recording work() invocations.
+ * Uses a custom getter for `worker` to avoid the super-ctor init-order footgun.
+ */
+private class TestScheduler(
+    mutex: String,
+    factory: MutexContendServiceFactory,
+    private val configValue: ScheduleConfig,
+    private val workerName: String,
+    private val latch: CountDownLatch,
+    private val counter: AtomicInteger,
+    private val shouldThrow: Boolean = false
+) : AbstractScheduler(mutex, factory) {
+    override val config: ScheduleConfig get() = configValue
+    override val worker: String get() = workerName
+    override fun work() {
+        if (shouldThrow && counter.get() == 0) {
+            throw IllegalStateException("work-boom")
+        }
+        counter.incrementAndGet()
+        latch.countDown()
+    }
+}
+
+/**
+ * Factory exposing the created contender so tests can drive onAcquired/onReleased.
+ */
+private class CapturingFactory : MutexContendServiceFactory {
+    var contender: MutexContender? = null
+        private set
+
+    override fun createMutexContendService(mutexContender: MutexContender): me.ahoo.simba.core.MutexContendService {
+        contender = mutexContender
+        // Return a no-op contend service; tests call contender.onAcquired directly
+        return NoopContendService(mutexContender)
+    }
+}
+
+private class NoopContendService(contender: MutexContender) :
+    me.ahoo.simba.core.AbstractMutexContendService(contender, me.ahoo.simba.core.SameThreadExecutor) {
+    override fun startContend() {}
+    override fun stopContend() {}
+}
+
+class AbstractSchedulerTest {
+    @Test
+    fun `onAcquired schedules work at fixed rate`() {
+        val latch = CountDownLatch(1)
+        val counter = AtomicInteger(0)
+        val factory = CapturingFactory()
+        val scheduler = TestScheduler(
+            mutex = "m",
+            factory = factory,
+            configValue = ScheduleConfig.rate(Duration.ofMillis(0), Duration.ofMillis(50)),
+            workerName = "rate-worker",
+            latch = latch,
+            counter = counter
+        )
+        val contender = factory.contender!! as AbstractScheduler.WorkContender
+
+        try {
+            scheduler.start()
+            contender.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(contender.contenderId, 0, 100, 200)))
+
+            assertThat("work should run at least once", latch.await(2, TimeUnit.SECONDS))
+            assertThat(counter.get(), greaterThanOrEqualTo(1))
+        } finally {
+            scheduler.stop()
+        }
+    }
+
+    @Test
+    fun `onAcquired schedules work with fixed delay`() {
+        val latch = CountDownLatch(1)
+        val counter = AtomicInteger(0)
+        val factory = CapturingFactory()
+        val scheduler = TestScheduler(
+            mutex = "m",
+            factory = factory,
+            configValue = ScheduleConfig.delay(Duration.ofMillis(0), Duration.ofMillis(50)),
+            workerName = "delay-worker",
+            latch = latch,
+            counter = counter
+        )
+        val contender = factory.contender!! as AbstractScheduler.WorkContender
+
+        try {
+            scheduler.start()
+            contender.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(contender.contenderId, 0, 100, 200)))
+
+            assertThat("work should run at least once", latch.await(2, TimeUnit.SECONDS))
+            assertThat(counter.get(), greaterThanOrEqualTo(1))
+        } finally {
+            scheduler.stop()
+        }
+    }
+
+    @Test
+    fun `onReleased cancels scheduled work without throwing`() {
+        val latch = CountDownLatch(1)
+        val counter = AtomicInteger(0)
+        val factory = CapturingFactory()
+        val scheduler = TestScheduler(
+            mutex = "m",
+            factory = factory,
+            configValue = ScheduleConfig.rate(Duration.ofMillis(0), Duration.ofMillis(50)),
+            workerName = "release-worker",
+            latch = latch,
+            counter = counter
+        )
+        val contender = factory.contender!! as AbstractScheduler.WorkContender
+
+        try {
+            scheduler.start()
+            contender.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(contender.contenderId, 0, 100, 200)))
+            // cancel the scheduled future
+            contender.onReleased(MutexState(MutexOwner(contender.contenderId, 0, 100, 200), MutexOwner.NONE))
+        } finally {
+            scheduler.stop()
+        }
+    }
+
+    @Test
+    fun `safeWork swallows work exception and keeps scheduling`() {
+        val latch = CountDownLatch(2)
+        val counter = AtomicInteger(0)
+        val factory = CapturingFactory()
+        val scheduler = TestScheduler(
+            mutex = "m",
+            factory = factory,
+            configValue = ScheduleConfig.rate(Duration.ofMillis(0), Duration.ofMillis(20)),
+            workerName = "throw-worker",
+            latch = latch,
+            counter = counter,
+            shouldThrow = true
+        )
+        val contender = factory.contender!! as AbstractScheduler.WorkContender
+
+        try {
+            scheduler.start()
+            contender.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(contender.contenderId, 0, 100, 200)))
+
+            assertThat("work should continue after a thrown exception", latch.await(2, TimeUnit.SECONDS))
+            assertThat(counter.get(), greaterThanOrEqualTo(2))
+        } finally {
+            scheduler.stop()
+        }
+    }
+
+    @Test
+    fun `running reflects contend service status`() {
+        val latch = CountDownLatch(1)
+        val counter = AtomicInteger(0)
+        val factory = CapturingFactory()
+        val scheduler = TestScheduler(
+            mutex = "m",
+            factory = factory,
+            configValue = ScheduleConfig.rate(Duration.ofMillis(0), Duration.ofMillis(50)),
+            workerName = "running-worker",
+            latch = latch,
+            counter = counter
+        )
+
+        assertThat(scheduler.running, equalTo(false))
+        scheduler.start()
+        assertThat(scheduler.running, equalTo(true))
+        scheduler.stop()
+        assertThat(scheduler.running, equalTo(false))
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew simba-core:test --tests "me.ahoo.simba.schedule.AbstractSchedulerTest"`
+Expected: PASS. If timing-sensitive tests are flaky, increase the `await` timeout or the period. The `safeWork swallows` test expects at least 2 invocations — with `shouldThrow=true` only the first throws, so subsequent runs succeed and decrement the latch.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add simba-core/src/test/kotlin/me/ahoo/simba/schedule/AbstractSchedulerTest.kt
+git commit -m "test(core): add AbstractScheduler scheduling and error handling tests"
+```
+
+---
+
+## Task 15: Final verification
+
+- [ ] **Step 1: Run the full simba-core test suite**
+
+Run: `./gradlew simba-core:test`
+Expected: BUILD SUCCESSFUL, all tests pass. Note the test count — should be ~70+ tests across 13+1 files.
+
+- [ ] **Step 2: Run detekt on simba-core**
+
+Run: `./gradlew simba-core:detekt`
+Expected: BUILD SUCCESSFUL (no style violations). If detekt flags formatting, run `./gradlew simba-core:detektMain --auto-correct` and re-run.
+
+- [ ] **Step 3: Regenerate the coverage report (optional, requires only simba-core)**
+
+Run: `./gradlew codeCoverageReport`
+Expected: BUILD SUCCESSFUL. Open `code-coverage-report/build/reports/jacoco/codeCoverageReport/html/index.html` and verify `me.ahoo.simba.core` line coverage is now ~95%+ and branch coverage is substantially improved over the prior ~80%/weak baseline.
+
+- [ ] **Step 4: Confirm git diff is clean and commit any auto-corrections**
+
+Run: `git diff --check && git status`
+Expected: no whitespace errors, only the new test files staged/committed. If detekt auto-correct modified files, commit them:
+
+```bash
+git add -A
+git commit -m "style(core): apply detekt formatting to tests"
+```
+
+- [ ] **Step 5: Push the branch and open a PR**
+
+```bash
+git push -u origin test/simba-core-coverage
+gh pr create --title "test(core): improve simba-core unit test coverage" --body "Adds 13 focused unit test files (+ shared TestDoubles) to simba-core, raising direct line coverage from ~80% to ~95%+ and substantially improving branch coverage. No production code changes; no external services required. See docs/superpowers/specs/2026-07-07-simba-core-test-coverage-design.md for the design."
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+- §4.1 AbstractMutexRetrievalService → Task 8 ✅
+- §4.2 MutexState → Task 2 ✅
+- §4.3 MutexOwner → Task 3 ✅
+- §4.4 AbstractMutexContender → Task 5 ✅
+- §4.5 ContendPeriod (extend) → Task 4 ✅
+- §4.6 MutexContender → Task 6 ✅
+- §4.7 SimbaLocker → Task 13 ✅
+- §4.8 AbstractScheduler → Task 14 ✅
+- §4.9 ContenderIdGenerator → Task 9 ✅
+- §4.10 ScheduleConfig → Task 12 ✅
+- §4.11 Threads → Task 11 ✅
+- §4.12 MutexRetrievalService → Task 7 ✅
+- §4.13 Simba + SimbaException → Task 10 ✅
+- TestDoubles.kt → Task 1 ✅
+
+**Type consistency check:** `FakeMutexContendService` (Task 1) exposes `publishOwner` used in Tasks 7 and 8. `SameThreadExecutor` (Task 1) used in Tasks 13 and 14. `FixedClockOwner` (Task 1) used in Tasks 2, 3, 4. Task 13 uses its own local `ControllableFactory`/`ControllableContendService` (because `SimbaLocker` builds its service in its own constructor — needs a lazy factory, not the pre-built `FakeContendServiceFactory`). Task 14 likewise uses its own `CapturingFactory`/`NoopContendService` for the same reason (`AbstractScheduler` builds its contender in its constructor). All names match across tasks.
+
+**Known risk:** Task 13's `acquire returns when onAcquired unparks` polls `ownerThread.state == WAITING` before marking ownership, then awaits a `CountDownLatch` with a 2-second timeout. The poll loop avoids the flakiness of a fixed `Thread.sleep`. If the thread never reaches `WAITING` (e.g., contention on the JVM), the poll loop throws a clear `AssertionError` after 2 seconds rather than hanging indefinitely. Task 14's timing-sensitive tests use 2-second `CountDownLatch.await` with short (20–50ms) periods; if flaky in CI, increase the await timeout or the period.

--- a/docs/superpowers/specs/2026-07-07-simba-core-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-07-simba-core-test-coverage-design.md
@@ -1,0 +1,206 @@
+# Design: simba-core Unit Test Coverage Improvement
+
+**Date:** 2026-07-07
+**Scope:** `simba-core` module only (no external services required)
+**Goal:** Raise direct unit-test coverage of `simba-core` from ~80% line / weak branch coverage toward ~95%+ line coverage with comprehensive branch coverage, by adding focused unit tests for every source file with branch logic.
+
+## 1. Problem Statement
+
+`simba-core` is the most foundational module (public mutex abstractions, lifecycle state machine, scheduling, `SimbaLocker`). Despite its importance:
+
+- It has **20 main source files but only 1 test file** (`ContendPeriodTest.kt`, covering a single branch of `nextOwnerDelay`).
+- Its ~80% line coverage comes **indirectly** from downstream TCK tests in `simba-jdbc`/`simba-redis`/`simba-zookeeper` — not from in-module unit tests. This means the module cannot be validated in isolation.
+- The aggregate **branch coverage is 51.4%**, the weakest metric across the project. Conditionals in the state machine, value-type predicates, and contender dispatch are under-exercised.
+- Key classes have **0% direct coverage**: `AbstractMutexRetrievalService` (the lifecycle state machine), `Simba`, `SimbaException`, `UUIDContenderIdGenerator`, and the `MutexMessageListener`-adjacent core types.
+
+This design fills those gaps with pure unit tests that run without Redis/MySQL/Zookeeper.
+
+## 2. Design Principles
+
+1. **Strict style alignment with `ContendPeriodTest.kt`:**
+   - Hamcrest assertions (`MatcherAssert.assertThat` + `Matchers.*`), NOT JUnit `Assertions.assertEquals`.
+   - JUnit Jupiter `@Test` (`org.junit.jupiter.api.Test`).
+   - Backtick descriptive test method names (`` `owner delay uses owner clock` ``).
+   - Apache 2.0 license header on every new file.
+   - Package mirrors main source (`me.ahoo.simba.core`, `me.ahoo.simba.schedule`, etc.).
+   - Class naming `<SubjectUnderTest>Test`.
+2. **Fakes over mocks.** Provide minimal in-module subclasses (e.g. `FakeMutexContendService`) instead of MockK — matches TCK convention (`MutexContendServiceSpec` uses anonymous `object : AbstractMutexContender` subclasses, no mocks). MockK stays available but unused unless a fake is impractical.
+3. **Deterministic time.** Reuse the `FixedClockOwner` pattern (subclass `MutexOwner`, override `currentAt`) for all time-dependent logic. Pass all 4 `MutexOwner` constructor args explicitly in tests.
+4. **Deterministic async.** Use a synchronous `Executor { it.run() }` when driving `AbstractMutexRetrievalService.notifyOwner`, so `CompletableFuture.runAsync` runs inline and `safeNotifyOwner`'s try/catch is testable without waiting.
+5. **No external services.** Every test runs in plain `./gradlew simba-core:test`. No Redis, MySQL, Zookeeper, Testcontainers.
+6. **Concurrency safety.** `SimbaLocker.acquire()` blocks via `LockSupport.park` — unit-test the timeout and double-acquire branches directly; for the happy path, drive `onAcquired` from a separate thread with `CountDownLatch` awaitability (mirroring `MutexContendServiceSpec`). `AbstractScheduler` uses a real `ScheduledThreadPoolExecutor` — always `stop()` in `finally` to release non-daemon threads.
+
+## 3. Test Doubles (shared, defined in-module)
+
+Defined once under `simba-core/src/test/kotlin/me/ahoo/simba/core/`:
+
+- **`FixedClockOwner`** — `MutexOwner` subclass with overrideable `currentAt`. (Already exists privately in `ContendPeriodTest`; promote to a top-level test helper so all tests reuse it.)
+- **`FakeMutexContender`** — implements `MutexContender`; records `onAcquired`/`onReleased` calls into lists. Inherits the default `notifyOwner` dispatch (exercising its 4 branches).
+- **`FakeMutexContendService`** — extends `AbstractMutexContendService`; configurable `ownerToNotify`, `throwOnStartRetrieval`, `throwOnStopRetrieval`; exposes the protected `notifyOwner` via a public test method; uses a synchronous executor by default.
+- **`FakeContendServiceFactory`** — `MutexContendServiceFactory` returning a preconfigured `FakeMutexContendService` (used by `SimbaLocker` and `AbstractScheduler` tests).
+- **`NoopContendServiceFactory`** — variant for `SimbaLocker` tests where we control `isOwner` directly.
+
+## 4. Test File Plan (13 files)
+
+All paths under `simba-core/src/test/kotlin/me/ahoo/simba/`.
+
+### P0 — Critical state machine & value types (highest branch density)
+
+#### 4.1 `core/AbstractMutexRetrievalServiceTest.kt`
+Target: the lifecycle state machine — currently 0% direct coverage.
+
+Branch coverage:
+- `start()` CAS success: INITIAL → STARTING → (startRetrieval) → RUNNING. Assert status transitions and that `startRetrieval` was invoked.
+- `start()` CAS failure: calling `start()` from RUNNING → `IllegalStateException("Cannot start from state [RUNNING]...")`. Also test STARTING/STOPPING states.
+- `start()` try/catch rollback: `FakeMutexContendService.throwOnStartRetrieval = RuntimeException` → assert status resets to INITIAL **and** exception propagates.
+- `stop()` CAS success: RUNNING → STOPPING → (stopRetrieval) → INITIAL (in `finally`). Assert `stopRetrieval` invoked.
+- `stop()` CAS failure: `stop()` from INITIAL → `IllegalStateException("Cannot stop...from state:[INITIAL]...")`.
+- `stop()` finally resets on throw: `throwOnStopRetrieval = RuntimeException` → assert status == INITIAL **and** exception propagates.
+- `safeNotifyOwner` try/catch swallows: `FakeMutexContender` whose `notifyOwner` throws → `notifyOwner(...).join()` completes without exception; `mutexState` was still updated (assignment happens before the throw, per the "Order of assignment" comment).
+- `safeNotifyOwner` happy path: newOwner applied; `retriever.notifyOwner(newState)` called with correct before/after.
+- `close()` delegates to `stop()`: from INITIAL → `IllegalStateException`.
+- `resetOwner()` sets `mutexState = MutexState.NONE` (exercised via `AbstractMutexContendService.startRetrieval` calling it).
+
+Uses synchronous `Executor` and `FakeMutexContendService`/`FakeMutexContender`.
+
+#### 4.2 `core/MutexStateTest.kt`
+Branch coverage for each predicate (true/false combos):
+- `isChanged`: `MutexState(A, A)` → false; `MutexState(A, B)` → true; `MutexState.NONE.isChanged` → false.
+- `isAcquired(contenderId)`: changed+owner → true; changed+non-owner → false; unchanged+owner → false.
+- `isReleased(contenderId)`: changed+before-owner → true; changed+not-before-owner → false; unchanged → false.
+- `isOwner(contenderId)`: after == contenderId → true/false.
+- `isInTtl(contenderId)`: owner+inTtl, owner+expired, non-owner.
+- Data class contract: `equals`/`hashCode`/`copy`/`component1`/`component2`; `NONE == MutexState(MutexOwner.NONE, MutexOwner.NONE)`.
+
+#### 4.3 `core/MutexOwnerTest.kt`
+Branch coverage (using `FixedClockOwner`):
+- `isOwner(contenderId)`: true/false.
+- `isInTtl`: `ttlAt > currentAt` true; `ttlAt == currentAt` false (strict `>`); `ttlAt < currentAt` false.
+- `isInTtl(contenderId)`: owner×inTtl, owner×expired, non-owner×inTtl (short-circuits false).
+- `isInTransition`: `transitionAt >= currentAt` true at equality boundary; `transitionAt < currentAt` false.
+- `isInTransitionOf(contenderId)`: 4 combos.
+- `hasOwner()`: `transitionAt >= currentAt` boundary; `MutexOwner.NONE.hasOwner()` → false.
+- Default args: `MutexOwner("x")` → `isInTtl == true`, `isInTransition == true`, `hasOwner() == true` (MAX_VALUE > now).
+- Companion: `NONE_OWNER_ID == ""`; `NONE` is `MutexOwner("", 0, 0, 0)` with `isInTtl == false`, `isInTransition == false`, `hasOwner() == false`.
+
+#### 4.4 `core/AbstractMutexContenderTest.kt`
+Branch coverage:
+- `require(mutex.isNotBlank())`: `""` and `"   "` (whitespace) → `IllegalArgumentException("mutex must not be blank!")`.
+- `require(contenderId.isNotBlank())`: blank contenderId → `IllegalArgumentException("contenderId must not be blank!")`.
+- Default `contenderId` arg: omit it → assert non-blank id matching `HostContenderIdGenerator` format `"\d+:\d+@.+"`.
+- `onAcquired`/`onReleased` default impls: subclass and invoke; they exercise the `log.info {}` lambda (no exception).
+- `final override val mutex`/`contenderId` are the constructor args.
+
+#### 4.5 `core/ContendPeriodTest.kt` (extend existing)
+Add to the existing file:
+- `ensureNextDelay`: negative computed delay (owner with `ttlAt < currentAt`) → returns `0`; positive → returns computed value.
+- `nextDelay`: owner branch (delegates to `nextOwnerDelay`) vs contender branch (delegates to `nextContenderDelay`).
+- `nextContenderDelay` `transition == 0L` branch: `transitionAt == ttlAt` → min = 0; `transitionAt > ttlAt` → min = -200. Assert result falls in expected `[transitionAt - now + min, transitionAt - now + 1000)` range (ThreadLocalRandom is non-deterministic → range assertion).
+
+### P1 — Contender dispatch, locker, scheduler (real branches)
+
+#### 4.6 `core/MutexContenderTest.kt`
+Tests the default `notifyOwner` interface dispatch (4 branches) via `FakeMutexContender`:
+- `!mutexState.isChanged` → early return; neither callback fires (`MutexState(A, A)`).
+- `isAcquired(contenderId)` → `onAcquired` called once (`MutexState(B, A)` where A is contender).
+- `isReleased(contenderId)` → `onReleased` called once (`MutexState(A, B)` where A is contender).
+- Combined role-swap `MutexState(A, B)` with contender A → `onReleased` for A; with contender B → `onAcquired` for B (assert per-contender only one fires).
+
+#### 4.7 `locker/SimbaLockerTest.kt`
+Branch coverage:
+- `acquire(timeout)` CAS failure: double-acquire from same thread → `IllegalMonitorStateException("Thread[...] already owns this lock[...].")`.
+- `acquire(timeout)` timeout: fake service with `isOwner == false` and short timeout → `TimeoutException("Could not acquire [$contenderId]@mutex:[$mutex] within timeout of ${...}ms")`.
+- `acquire(timeout)` success: fake service flips `isOwner` to true before timeout → returns normally.
+- `acquire()` CAS failure: same `IllegalMonitorStateException` (no timeout variant).
+- `acquire()` happy path: acquire from a separate thread; fake service invokes `onAcquired` (which calls `LockSupport.unpark`) → calling thread unparks and returns. Use `CountDownLatch` to synchronize.
+- `onAcquired`: calls `super.onAcquired` (logs) then `LockSupport.unpark(OWNER[this])`; when `OWNER[this]` is null (not acquired) → no-op, no exception.
+- `close()`: delegates to `contendService.stop()`; calling `close()` without prior `acquire()` (status INITIAL) → `IllegalStateException`.
+
+Uses `FakeContendServiceFactory` / `NoopContendServiceFactory` controlling `isOwner`.
+
+#### 4.8 `schedule/AbstractSchedulerTest.kt`
+Branch coverage:
+- `WorkContender.onAcquired` guard `workFuture == null || isDone`: first acquire schedules; second acquire while scheduled does NOT reschedule (assert only one `ScheduledFuture` exists / `work()` invocation count respects single schedule).
+- Strategy branch: `ScheduleConfig.rate(...)` → `scheduleAtFixedRate`; `ScheduleConfig.delay(...)` → `scheduleWithFixedDelay`. Assert `work()` is invoked in both modes (via `CountDownLatch`).
+- `onReleased`: `workFuture?.cancel(true)` — cancel an active future; release before any acquire (future null) is a no-op.
+- `safeWork` try/catch: `work()` throws → exception logged and swallowed, scheduled task continues (next period still runs). Assert via a second `work()` invocation after a thrown one.
+- `start()`/`stop()`/`running`: delegate to `contendService`; `running` reflects `status.isActive`.
+
+Uses a concrete `AbstractScheduler` subclass with a `CountDownLatch`-recording `work()` and `ScheduleConfig.rate`/`.delay`. Always `stop()` in `finally`.
+
+### P2 — Constants, factories, utilities (low branch density but closes 0% files)
+
+#### 4.9 `core/ContenderIdGeneratorTest.kt`
+- `UUIDContenderIdGenerator.generate()`: 32 hex chars, matches `[0-9a-f]{32}`, two calls differ.
+- `HostContenderIdGenerator.generate()`: matches `\d+:\d+@.+`, counter increments (first call counter=0, second=1).
+- Companion `@JvmField`s: `ContenderIdGenerator.UUID === UUIDContenderIdGenerator`, `HOST === HostContenderIdGenerator`.
+
+#### 4.10 `schedule/ScheduleConfigTest.kt`
+- `rate(initialDelay, period).strategy == FIXED_RATE`.
+- `delay(initialDelay, period).strategy == FIXED_DELAY`.
+- Data class `equals`/`copy`/`componentN`.
+- `enum class Strategy` has exactly `[FIXED_DELAY, FIXED_RATE]` in order.
+
+#### 4.11 `util/ThreadsTest.kt`
+- `Threads.defaultFactory("foo")`: `newThread(runnable)` → `isDaemon == false`, `name == "foo-0"` (first), `"foo-1"` (second).
+
+#### 4.12 `core/MutexRetrievalServiceTest.kt`
+- `Status.isActive`: INITIAL → false, STARTING → true, RUNNING → true, STOPPING → false.
+- `hasOwner()` default: `afterOwner !== MutexOwner.NONE` → true when after is a real owner, false when after is `MutexOwner.NONE` (identity).
+- (Interface defaults exercised via `FakeMutexContendService`.)
+
+#### 4.13 `SimbaTest.kt` + `SimbaExceptionTest.kt`
+- `SimbaTest`: `Simba.SIMBA == "simba"`, `Simba.SIMBA_PREFIX == "simba."`.
+- `SimbaExceptionTest`: instantiate all 5 constructors; assert `message`, `cause`, `suppressed`, `stackTrace` fields; assert it IS-A `RuntimeException`; assert `open` allows subclassing.
+
+## 5. Files Changed
+
+**New (13 test files + 1 shared helper):**
+- `simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt` (shared `FixedClockOwner`, `FakeMutexContender`, `FakeMutexContendService`, `FakeContendServiceFactory`, `NoopContendServiceFactory`)
+- `simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/core/MutexStateTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/core/MutexOwnerTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexContenderTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/core/MutexContenderTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/core/ContenderIdGeneratorTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/core/MutexRetrievalServiceTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/schedule/AbstractSchedulerTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/schedule/ScheduleConfigTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/util/ThreadsTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/SimbaTest.kt`
+- `simba-core/src/test/kotlin/me/ahoo/simba/SimbaExceptionTest.kt`
+
+**Modified (1):**
+- `simba-core/src/test/kotlin/me/ahoo/simba/core/ContendPeriodTest.kt` — extend with `ensureNextDelay`/`nextDelay`/`nextContenderDelay` branch tests; replace private `FixedClockOwner` with import from `TestDoubles.kt`.
+
+**No production code changes.** No `build.gradle.kts` changes (all test deps already on classpath via root `configure(libraryProjects)`).
+
+## 6. Verification
+
+```bash
+./gradlew simba-core:test                 # all new tests pass
+./gradlew simba-core:detekt               # style clean
+./gradlew codeCoverageReport              # regenerate aggregated report
+```
+
+Expected outcome:
+- `simba-core` line coverage → ~95%+ (from ~80%).
+- `simba-core` branch coverage → significant improvement (state machine, value types, contender dispatch fully covered).
+- No external services required; full run completes in seconds.
+
+## 7. Out of Scope
+
+- Other modules (`simba-jdbc`, `simba-spring-redis`, `simba-zookeeper`, `simba-spring-boot-starter`) — separate effort.
+- Adding Gradle `jacocoTestCoverageVerification` thresholds — separate decision; can be a follow-up once the new baseline is established.
+- Production code refactors — none. If a test reveals a genuine bug, stop and surface it rather than patching silently.
+
+## 8. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `SimbaLocker.acquire()` blocks the test thread | Use `acquire(timeout)` for direct tests; for happy path, run `acquire()` on a separate thread and unpark via `onAcquired` with `CountDownLatch` synchronization. Hard timeout on test thread join to prevent hangs. |
+| `AbstractScheduler` uses non-daemon threads → JVM won't exit | Always `stop()` in `finally`; fail test if executor threads linger (assert via thread name lookup if needed). |
+| `ThreadLocalRandom` in `ContendPeriod.nextContenderDelay` is non-deterministic | Assert result range, not exact value; run multiple iterations to exercise both `transition == 0` and `!= 0` branches reliably. |
+| `HostContenderIdGenerator` counter is global state shared across tests | Assert relative increments (call N+1 > call N), not absolute values; tolerate any starting counter. |
+| Promoting `FixedClockOwner` out of `ContendPeriodTest` breaks the existing test | Update `ContendPeriodTest` to import from `TestDoubles.kt` in the same change; verify it still passes. |

--- a/simba-core/src/test/kotlin/me/ahoo/simba/SimbaExceptionTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/SimbaExceptionTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.instanceOf
+import org.hamcrest.Matchers.nullValue
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+
+class SimbaExceptionTest {
+    @Test
+    fun `is a RuntimeException`() {
+        assertThat(SimbaException(), instanceOf(RuntimeException::class.java))
+    }
+
+    @Test
+    fun `default constructor has null message and cause`() {
+        val ex = SimbaException()
+        assertThat(ex.message, nullValue())
+        assertThat(ex.cause, nullValue())
+    }
+
+    @Test
+    fun `message constructor sets message`() {
+        val ex = SimbaException("msg")
+        assertThat(ex.message, equalTo("msg"))
+        assertThat(ex.cause, nullValue())
+    }
+
+    @Test
+    fun `message and cause constructor sets both`() {
+        val cause = IllegalStateException("root")
+        val ex = SimbaException("msg", cause)
+        assertThat(ex.message, equalTo("msg"))
+        assertThat(ex.cause, sameInstance(cause))
+    }
+
+    @Test
+    fun `cause constructor sets cause`() {
+        val cause = IllegalStateException("root")
+        val ex = SimbaException(cause)
+        assertThat(ex.cause, sameInstance(cause))
+    }
+
+    @Test
+    fun `full constructor sets suppression and stack trace flags`() {
+        val cause = IllegalStateException("root")
+        val ex = SimbaException("msg", cause, true, false)
+
+        assertThat(ex.message, equalTo("msg"))
+        assertThat(ex.cause, sameInstance(cause))
+    }
+
+    @Test
+    fun `open class allows subclassing`() {
+        class CustomSimbaException : SimbaException("custom")
+
+        val sub = CustomSimbaException()
+        assertThat(sub, instanceOf(SimbaException::class.java))
+        assertThat(sub.message, equalTo("custom"))
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/SimbaTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/SimbaTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+class SimbaTest {
+    @Test
+    fun `SIMBA constant is simba`() {
+        assertThat(Simba.SIMBA, equalTo("simba"))
+    }
+
+    @Test
+    fun `SIMBA_PREFIX constant is simba dot`() {
+        assertThat(Simba.SIMBA_PREFIX, equalTo("simba."))
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexContenderTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexContenderTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.blankOrNullString
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.matchesPattern
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AbstractMutexContenderTest {
+    private fun newContender(mutex: String, contenderId: String = "c1"): AbstractMutexContender {
+        return object : AbstractMutexContender(mutex, contenderId) {}
+    }
+
+    @Test
+    fun `rejects blank mutex`() {
+        val error = assertThrows<IllegalArgumentException> { newContender("") }
+        assertThat(error.message, equalTo("mutex must not be blank!"))
+    }
+
+    @Test
+    fun `rejects whitespace-only mutex`() {
+        val error = assertThrows<IllegalArgumentException> { newContender("   ") }
+        assertThat(error.message, equalTo("mutex must not be blank!"))
+    }
+
+    @Test
+    fun `rejects blank contenderId`() {
+        val error = assertThrows<IllegalArgumentException> { newContender("m", "") }
+        assertThat(error.message, equalTo("contenderId must not be blank!"))
+    }
+
+    @Test
+    fun `rejects whitespace-only contenderId`() {
+        val error = assertThrows<IllegalArgumentException> { newContender("m", "  ") }
+        assertThat(error.message, equalTo("contenderId must not be blank!"))
+    }
+
+    @Test
+    fun `default contenderId is generated host format`() {
+        val contender = object : AbstractMutexContender("m") {}
+        assertThat(contender.contenderId, not(blankOrNullString()))
+        assertThat(
+            contender.contenderId,
+            matchesPattern("\\d+:\\d+@.+")
+        )
+    }
+
+    @Test
+    fun `onAcquired and onReleased do not throw`() {
+        val contender = newContender("m", "c1")
+        val state = MutexState(MutexOwner.NONE, MutexOwner("c1", 0, 100, 200))
+
+        contender.onAcquired(state)
+        contender.onReleased(state)
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AbstractMutexRetrievalServiceTest {
+    private fun newService(): FakeMutexContendService {
+        val contender = FakeMutexContender("m", "c1")
+        return FakeMutexContendService(contender)
+    }
+
+    @Test
+    fun `start transitions INITIAL to RUNNING and calls startContend`() {
+        val service = newService()
+
+        service.start()
+
+        assertThat(service.status, equalTo(MutexRetrievalService.Status.RUNNING))
+        assertThat(service.startContendCalled, equalTo(true))
+        service.stop()
+    }
+
+    @Test
+    fun `start from RUNNING throws IllegalStateException`() {
+        val service = newService()
+        service.start()
+
+        val error = assertThrows<IllegalStateException> { service.start() }
+        assertThat(error.message, equalTo("Cannot start from state [RUNNING]. Expected: [INITIAL]"))
+
+        service.stop()
+    }
+
+    @Test
+    fun `start rollback to INITIAL when startContend throws`() {
+        val service = newService()
+        service.throwOnStartContend = IllegalStateException("boom")
+
+        val error = assertThrows<IllegalStateException> { service.start() }
+
+        assertThat(error.message, equalTo("boom"))
+        assertThat(service.status, equalTo(MutexRetrievalService.Status.INITIAL))
+    }
+
+    @Test
+    fun `stop transitions RUNNING to INITIAL and calls stopContend`() {
+        val service = newService()
+        service.start()
+
+        service.stop()
+
+        assertThat(service.status, equalTo(MutexRetrievalService.Status.INITIAL))
+        assertThat(service.stopContendCalled, equalTo(true))
+    }
+
+    @Test
+    fun `stop from INITIAL throws IllegalStateException`() {
+        val service = newService()
+
+        val error = assertThrows<IllegalStateException> { service.stop() }
+        assertThat(error.message, equalTo("Cannot stop mutex:[m] from state:[INITIAL]. Expected:[RUNNING]"))
+    }
+
+    @Test
+    fun `stop resets to INITIAL even when stopContend throws`() {
+        val service = newService()
+        service.start()
+        service.throwOnStopContend = IllegalStateException("stop-boom")
+
+        val error = assertThrows<IllegalStateException> { service.stop() }
+
+        assertThat(error.message, equalTo("stop-boom"))
+        assertThat(service.status, equalTo(MutexRetrievalService.Status.INITIAL))
+    }
+
+    @Test
+    fun `publishOwner updates mutexState and notifies retriever`() {
+        val contender = FakeMutexContender("m", "c1")
+        val service = FakeMutexContendService(contender)
+        service.start()
+        val previous = MutexOwner("other", 0, 50, 100)
+        service.publishOwner(previous)
+
+        val newOwner = MutexOwner("c1", 0, 100, 200)
+        service.publishOwner(newOwner).join()
+
+        assertThat(service.afterOwner, sameInstance(newOwner))
+        assertThat(service.beforeOwner, sameInstance(previous))
+        // contender became owner -> onAcquired fired
+        assertThat(contender.acquired.size, equalTo(1))
+        service.stop()
+    }
+
+    @Test
+    fun `publishOwner swallows retriever exception and keeps mutexState`() {
+        val contender = FakeMutexContender("m", "c1")
+        contender.throwOnNotify = IllegalStateException("notify-boom")
+        val service = FakeMutexContendService(contender)
+        service.start()
+
+        val newOwner = MutexOwner("c1", 0, 100, 200)
+        // Should not throw despite retriever.notifyOwner throwing
+        service.publishOwner(newOwner).join()
+
+        // mutexState was assigned BEFORE the throw (order-of-assignment contract)
+        assertThat(service.afterOwner, sameInstance(newOwner))
+        // no exception escaped the CompletableFuture
+        assertThat(contender.acquired.size, equalTo(0))
+        service.stop()
+    }
+
+    @Test
+    fun `close delegates to stop and throws when not running`() {
+        val service = newService()
+
+        val error = assertThrows<IllegalStateException> { service.close() }
+        assertThat(error.message, equalTo("Cannot stop mutex:[m] from state:[INITIAL]. Expected:[RUNNING]"))
+    }
+
+    @Test
+    fun `start resets owner to NONE via resetOwner`() {
+        val contender = FakeMutexContender("m", "c1")
+        val service = FakeMutexContendService(contender)
+        service.start()
+        service.publishOwner(MutexOwner("c1", 0, 100, 200)).join()
+        assertThat(service.hasOwner(), equalTo(true))
+
+        service.stop()
+        service.start()
+
+        // startRetrieval -> resetOwner -> mutexState = NONE
+        assertThat(service.mutexState, equalTo(MutexState.NONE))
+        service.stop()
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/ContendPeriodTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/ContendPeriodTest.kt
@@ -15,6 +15,8 @@ package me.ahoo.simba.core
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.greaterThanOrEqualTo
+import org.hamcrest.Matchers.lessThan
 import org.junit.jupiter.api.Test
 
 class ContendPeriodTest {
@@ -30,13 +32,91 @@ class ContendPeriodTest {
         assertThat(ContendPeriod.nextOwnerDelay(owner), equalTo(400))
     }
 
-    private class FixedClockOwner(
-        ownerId: String,
-        ttlAt: Long,
-        transitionAt: Long,
-        private val fixedCurrentAt: Long
-    ) : MutexOwner(ownerId = ownerId, acquiredAt = 0, ttlAt = ttlAt, transitionAt = transitionAt) {
-        override val currentAt: Long
-            get() = fixedCurrentAt
+    @Test
+    fun `ensureNextDelay clamps negative delay to zero`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 500,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+        val period = ContendPeriod("owner")
+
+        assertThat(period.ensureNextDelay(owner), equalTo(0L))
+    }
+
+    @Test
+    fun `ensureNextDelay returns computed delay when positive`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 1400,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+        val period = ContendPeriod("owner")
+
+        assertThat(period.ensureNextDelay(owner), equalTo(400L))
+    }
+
+    @Test
+    fun `nextDelay delegates to owner delay when contender is owner`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 1400,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+        val period = ContendPeriod("owner")
+
+        assertThat(period.nextDelay(owner), equalTo(ContendPeriod.nextOwnerDelay(owner)))
+    }
+
+    @Test
+    fun `nextDelay delegates to contender delay when contender is not owner`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 1400,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+        val period = ContendPeriod("other")
+
+        // The owner branch would return exactly 400; the contender branch returns a
+        // non-deterministic value in [800, 2000) (transitionAt - currentAt + random).
+        // Asserting that range confirms the contender dispatch was taken.
+        val delay = period.nextDelay(owner)
+
+        assertThat(delay, greaterThanOrEqualTo(800L))
+        assertThat(delay, lessThan(2000L))
+    }
+
+    @Test
+    fun `nextContenderDelay with zero transition stays in non-negative range`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 2000,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+
+        val delay = ContendPeriod.nextContenderDelay(owner)
+
+        assertThat(delay, greaterThanOrEqualTo(1000L))
+        assertThat(delay, lessThan(2000L))
+    }
+
+    @Test
+    fun `nextContenderDelay with non-zero transition allows negative offset`() {
+        val owner = FixedClockOwner(
+            ownerId = "owner",
+            ttlAt = 1400,
+            transitionAt = 2000,
+            fixedCurrentAt = 1000
+        )
+
+        val delay = ContendPeriod.nextContenderDelay(owner)
+
+        assertThat(delay, greaterThanOrEqualTo(800L))
+        assertThat(delay, lessThan(2000L))
     }
 }

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/ContenderIdGeneratorTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/ContenderIdGeneratorTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.matchesPattern
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+
+class ContenderIdGeneratorTest {
+    @Test
+    fun `UUID generates 32 hex chars without dashes`() {
+        val id = UUIDContenderIdGenerator.generate()
+
+        assertThat(id.length, equalTo(32))
+        assertThat(id, matchesPattern("[0-9a-f]{32}"))
+    }
+
+    @Test
+    fun `UUID generates distinct ids`() {
+        assertThat(UUIDContenderIdGenerator.generate(), not(equalTo(UUIDContenderIdGenerator.generate())))
+    }
+
+    @Test
+    fun `HOST generates counter pid host format`() {
+        val id = HostContenderIdGenerator.generate()
+
+        assertThat(id, matchesPattern("\\d+:\\d+@.+"))
+    }
+
+    @Test
+    fun `HOST increments counter across calls`() {
+        val first = HostContenderIdGenerator.generate()
+        val second = HostContenderIdGenerator.generate()
+
+        val firstCounter = first.substringBefore(":").toLong()
+        val secondCounter = second.substringBefore(":").toLong()
+        assertThat(secondCounter, equalTo(firstCounter + 1L))
+    }
+
+    @Test
+    fun `companion UUID field is the singleton instance`() {
+        assertThat(ContenderIdGenerator.UUID, sameInstance(UUIDContenderIdGenerator))
+    }
+
+    @Test
+    fun `companion HOST field is the singleton instance`() {
+        assertThat(ContenderIdGenerator.HOST, sameInstance(HostContenderIdGenerator))
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexContenderTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexContenderTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+class MutexContenderTest {
+    private val ownerA = MutexOwner("A", 0, 100, 200)
+    private val ownerB = MutexOwner("B", 0, 100, 200)
+
+    @Test
+    fun `notifyOwner skips callbacks when state unchanged`() {
+        val contender = FakeMutexContender("m", "A")
+
+        contender.notifyOwner(MutexState(ownerA, ownerA))
+
+        assertThat(contender.acquired.size, equalTo(0))
+        assertThat(contender.released.size, equalTo(0))
+    }
+
+    @Test
+    fun `notifyOwner fires onAcquired when contender becomes owner`() {
+        val contender = FakeMutexContender("m", "B")
+
+        contender.notifyOwner(MutexState(ownerA, ownerB))
+
+        assertThat(contender.acquired.size, equalTo(1))
+        assertThat(contender.released.size, equalTo(0))
+    }
+
+    @Test
+    fun `notifyOwner fires onReleased when contender loses ownership`() {
+        val contender = FakeMutexContender("m", "A")
+
+        contender.notifyOwner(MutexState(ownerA, ownerB))
+
+        assertThat(contender.acquired.size, equalTo(0))
+        assertThat(contender.released.size, equalTo(1))
+    }
+
+    @Test
+    fun `notifyOwner fires only onAcquired for the new owner on role swap`() {
+        val newOwner = FakeMutexContender("m", "B")
+
+        newOwner.notifyOwner(MutexState(ownerA, ownerB))
+
+        assertThat(newOwner.acquired.size, equalTo(1))
+        assertThat(newOwner.released.size, equalTo(0))
+    }
+
+    @Test
+    fun `notifyOwner fires only onReleased for the previous owner on role swap`() {
+        val previousOwner = FakeMutexContender("m", "A")
+
+        previousOwner.notifyOwner(MutexState(ownerA, ownerB))
+
+        assertThat(previousOwner.acquired.size, equalTo(0))
+        assertThat(previousOwner.released.size, equalTo(1))
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexOwnerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexOwnerTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+class MutexOwnerTest {
+    @Test
+    fun `isOwner returns true when ids match`() {
+        val owner = MutexOwner("A", 0, 100, 200)
+        assertThat(owner.isOwner("A"), equalTo(true))
+    }
+
+    @Test
+    fun `isOwner returns false when ids differ`() {
+        val owner = MutexOwner("A", 0, 100, 200)
+        assertThat(owner.isOwner("B"), equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl is true when ttlAt greater than currentAt`() {
+        val owner = FixedClockOwner("A", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl, equalTo(true))
+    }
+
+    @Test
+    fun `isInTtl is false when ttlAt equals currentAt`() {
+        val owner = FixedClockOwner("A", ttlAt = 100, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl, equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl is false when ttlAt less than currentAt`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl, equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl contenderId is true for owner in ttl`() {
+        val owner = FixedClockOwner("A", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl("A"), equalTo(true))
+    }
+
+    @Test
+    fun `isInTtl contenderId is false for owner expired`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl("A"), equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl contenderId is false for non owner even if in ttl`() {
+        val owner = FixedClockOwner("A", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(owner.isInTtl("B"), equalTo(false))
+    }
+
+    @Test
+    fun `isInTransition is true at equality boundary`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 100, fixedCurrentAt = 100)
+        assertThat(owner.isInTransition, equalTo(true))
+    }
+
+    @Test
+    fun `isInTransition is false when transitionAt less than currentAt`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 50, fixedCurrentAt = 100)
+        assertThat(owner.isInTransition, equalTo(false))
+    }
+
+    @Test
+    fun `isInTransitionOf is true for owner in transition`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 200, fixedCurrentAt = 100)
+        assertThat(owner.isInTransitionOf("A"), equalTo(true))
+    }
+
+    @Test
+    fun `isInTransitionOf is false for non owner`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 200, fixedCurrentAt = 100)
+        assertThat(owner.isInTransitionOf("B"), equalTo(false))
+    }
+
+    @Test
+    fun `hasOwner is true at transition boundary`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 100, fixedCurrentAt = 100)
+        assertThat(owner.hasOwner(), equalTo(true))
+    }
+
+    @Test
+    fun `hasOwner is false when transitionAt less than currentAt`() {
+        val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 50, fixedCurrentAt = 100)
+        assertThat(owner.hasOwner(), equalTo(false))
+    }
+
+    @Test
+    fun `default args yield inTtl and inTransition true`() {
+        val owner = MutexOwner("A")
+        assertThat(owner.isInTtl, equalTo(true))
+        assertThat(owner.isInTransition, equalTo(true))
+        assertThat(owner.hasOwner(), equalTo(true))
+    }
+
+    @Test
+    fun `NONE constant has empty ownerId and is expired`() {
+        assertThat(MutexOwner.NONE.ownerId, equalTo(MutexOwner.NONE_OWNER_ID))
+        assertThat(MutexOwner.NONE_OWNER_ID, equalTo(""))
+        assertThat(MutexOwner.NONE.isInTtl, equalTo(false))
+        assertThat(MutexOwner.NONE.isInTransition, equalTo(false))
+        assertThat(MutexOwner.NONE.hasOwner(), equalTo(false))
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexRetrievalServiceTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexRetrievalServiceTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+class MutexRetrievalServiceTest {
+    @Test
+    fun `Status INITIAL is not active`() {
+        assertThat(MutexRetrievalService.Status.INITIAL.isActive, equalTo(false))
+    }
+
+    @Test
+    fun `Status STARTING is active`() {
+        assertThat(MutexRetrievalService.Status.STARTING.isActive, equalTo(true))
+    }
+
+    @Test
+    fun `Status RUNNING is active`() {
+        assertThat(MutexRetrievalService.Status.RUNNING.isActive, equalTo(true))
+    }
+
+    @Test
+    fun `Status STOPPING is not active`() {
+        assertThat(MutexRetrievalService.Status.STOPPING.isActive, equalTo(false))
+    }
+
+    @Test
+    fun `hasOwner is false when afterOwner is NONE by identity`() {
+        val service = FakeMutexContendService(FakeMutexContender("m", "c1"))
+        // mutexState defaults to MutexState.NONE -> afterOwner is MutexOwner.NONE
+        assertThat(service.hasOwner(), equalTo(false))
+    }
+
+    @Test
+    fun `hasOwner is true when afterOwner is a real owner`() {
+        val contender = FakeMutexContender("m", "c1")
+        val service = FakeMutexContendService(contender)
+        service.start()
+
+        service.publishOwner(MutexOwner("c1", 0, 100, 200))
+
+        assertThat(service.hasOwner(), equalTo(true))
+        service.stop()
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexRetrievalServiceTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexRetrievalServiceTest.kt
@@ -51,7 +51,7 @@ class MutexRetrievalServiceTest {
         val service = FakeMutexContendService(contender)
         service.start()
 
-        service.publishOwner(MutexOwner("c1", 0, 100, 200))
+        service.publishOwner(MutexOwner("c1", 0, 100, 200)).join()
 
         assertThat(service.hasOwner(), equalTo(true))
         service.stop()

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexStateTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexStateTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+
+class MutexStateTest {
+    private val ownerA = MutexOwner("A", 0, 100, 200)
+    private val ownerB = MutexOwner("B", 0, 100, 200)
+
+    @Test
+    fun `isChanged is false when before and after share ownerId`() {
+        assertThat(MutexState(ownerA, ownerA).isChanged, equalTo(false))
+    }
+
+    @Test
+    fun `isChanged is false for NONE`() {
+        assertThat(MutexState.NONE.isChanged, equalTo(false))
+    }
+
+    @Test
+    fun `isChanged is true when owners differ`() {
+        assertThat(MutexState(ownerA, ownerB).isChanged, equalTo(true))
+    }
+
+    @Test
+    fun `isAcquired is true when changed and after owns`() {
+        assertThat(MutexState(ownerA, ownerB).isAcquired("B"), equalTo(true))
+    }
+
+    @Test
+    fun `isAcquired is false when unchanged even if after owns`() {
+        assertThat(MutexState(ownerB, ownerB).isAcquired("B"), equalTo(false))
+    }
+
+    @Test
+    fun `isAcquired is false when changed but after does not own`() {
+        assertThat(MutexState(ownerA, ownerB).isAcquired("A"), equalTo(false))
+    }
+
+    @Test
+    fun `isReleased is true when changed and before owns`() {
+        assertThat(MutexState(ownerA, ownerB).isReleased("A"), equalTo(true))
+    }
+
+    @Test
+    fun `isReleased is false when unchanged`() {
+        assertThat(MutexState(ownerA, ownerA).isReleased("A"), equalTo(false))
+    }
+
+    @Test
+    fun `isReleased is false when changed but before does not own`() {
+        assertThat(MutexState(ownerA, ownerB).isReleased("B"), equalTo(false))
+    }
+
+    @Test
+    fun `isOwner delegates to after owner`() {
+        assertThat(MutexState(ownerA, ownerB).isOwner("B"), equalTo(true))
+        assertThat(MutexState(ownerA, ownerB).isOwner("A"), equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl is true when owner and after in ttl`() {
+        val inTtl = FixedClockOwner("B", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(MutexState(ownerA, inTtl).isInTtl("B"), equalTo(true))
+    }
+
+    @Test
+    fun `isInTtl is false when owner but after expired`() {
+        val expired = FixedClockOwner("B", ttlAt = 50, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(MutexState(ownerA, expired).isInTtl("B"), equalTo(false))
+    }
+
+    @Test
+    fun `isInTtl is false when not owner`() {
+        val inTtl = FixedClockOwner("B", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
+        assertThat(MutexState(ownerA, inTtl).isInTtl("A"), equalTo(false))
+    }
+
+    @Test
+    fun `data class equals and copy`() {
+        val state = MutexState(ownerA, ownerB)
+        val copy = state.copy()
+        assertThat(copy, equalTo(state))
+        assertThat(copy, not(sameInstance(state)))
+    }
+
+    @Test
+    fun `data class component destructuring`() {
+        val (before, after) = MutexState(ownerA, ownerB)
+        assertThat(before, equalTo(ownerA))
+        assertThat(after, equalTo(ownerB))
+    }
+
+    @Test
+    fun `NONE equals state of two NONE owners`() {
+        assertThat(MutexState.NONE, equalTo(MutexState(MutexOwner.NONE, MutexOwner.NONE)))
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt
@@ -96,11 +96,11 @@ class FakeMutexContendService(
     }
 }
 
-/**
- * [MutexContendServiceFactory] that returns a preconfigured service.
+/*
+ * No shared MutexContendServiceFactory is provided here because the classes that need one
+ * (SimbaLocker, AbstractScheduler) build their contend service *inside their own constructor*
+ * via the factory — so the factory must construct the service lazily, using the contender
+ * passed to createMutexContendService (which is the locker/scheduler itself). A pre-built
+ * factory cannot work because its service's contender would be fixed before the locker exists.
+ * See SimbaLockerTest.ControllableFactory and AbstractSchedulerTest.CapturingFactory.
  */
-class FakeContendServiceFactory(private val service: MutexContendService) : MutexContendServiceFactory {
-    override fun createMutexContendService(mutexContender: MutexContender): MutexContendService {
-        return service
-    }
-}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.simba.core
 
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 
 /**
@@ -90,8 +91,8 @@ class FakeMutexContendService(
     }
 
     /** Exposes the protected [notifyOwner] for tests. */
-    fun publishOwner(newOwner: MutexOwner) {
-        notifyOwner(newOwner)
+    fun publishOwner(newOwner: MutexOwner): CompletableFuture<Void> {
+        return notifyOwner(newOwner)
     }
 }
 

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.core
+
+import java.util.concurrent.Executor
+
+/**
+ * [MutexOwner] with a fixed [currentAt] for deterministic time-based tests.
+ */
+class FixedClockOwner(
+    ownerId: String,
+    ttlAt: Long,
+    transitionAt: Long,
+    private val fixedCurrentAt: Long
+) : MutexOwner(ownerId = ownerId, acquiredAt = 0, ttlAt = ttlAt, transitionAt = transitionAt) {
+    override val currentAt: Long
+        get() = fixedCurrentAt
+}
+
+/**
+ * [MutexContender] that records [onAcquired]/[onReleased] calls.
+ * Inherits the default [notifyOwner] dispatch from [MutexContender].
+ */
+class FakeMutexContender(
+    override val mutex: String,
+    override val contenderId: String
+) : MutexContender {
+    val acquired = mutableListOf<MutexState>()
+    val released = mutableListOf<MutexState>()
+
+    var throwOnNotify: Throwable? = null
+
+    override fun notifyOwner(mutexState: MutexState) {
+        throwOnNotify?.let { throw it }
+        super.notifyOwner(mutexState)
+    }
+
+    override fun onAcquired(mutexState: MutexState) {
+        acquired += mutexState
+    }
+
+    override fun onReleased(mutexState: MutexState) {
+        released += mutexState
+    }
+}
+
+/**
+ * Synchronous executor that runs tasks inline on the calling thread.
+ */
+object SameThreadExecutor : Executor {
+    override fun execute(command: Runnable) {
+        command.run()
+    }
+}
+
+/**
+ * [AbstractMutexContendService] fake with controllable start/stop/notify behavior.
+ * Uses [SameThreadExecutor] by default so [notifyOwner] runs inline.
+ */
+class FakeMutexContendService(
+    contender: MutexContender,
+    handleExecutor: Executor = SameThreadExecutor,
+    var throwOnStartContend: Throwable? = null,
+    var throwOnStopContend: Throwable? = null
+) : AbstractMutexContendService(contender, handleExecutor) {
+    var startContendCalled = false
+        private set
+    var stopContendCalled = false
+        private set
+
+    override fun startContend() {
+        startContendCalled = true
+        throwOnStartContend?.let { throw it }
+    }
+
+    override fun stopContend() {
+        stopContendCalled = true
+        throwOnStopContend?.let { throw it }
+    }
+
+    /** Exposes the protected [notifyOwner] for tests. */
+    fun publishOwner(newOwner: MutexOwner) {
+        notifyOwner(newOwner)
+    }
+}
+
+/**
+ * [MutexContendServiceFactory] that returns a preconfigured service.
+ */
+class FakeContendServiceFactory(private val service: MutexContendService) : MutexContendServiceFactory {
+    override fun createMutexContendService(mutexContender: MutexContender): MutexContendService {
+        return service
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.locker
+
+import me.ahoo.simba.core.AbstractMutexContendService
+import me.ahoo.simba.core.MutexContendService
+import me.ahoo.simba.core.MutexContendServiceFactory
+import me.ahoo.simba.core.MutexContender
+import me.ahoo.simba.core.MutexOwner
+import me.ahoo.simba.core.MutexState
+import me.ahoo.simba.core.SameThreadExecutor
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Controllable contend service bound to the contender passed by the factory.
+ * Tests flip ownership by calling [markOwner], which dispatches to
+ * [AbstractMutexContendService.notifyOwner] -> contender.notifyOwner.
+ */
+private class ControllableContendService(
+    contender: MutexContender
+) : AbstractMutexContendService(contender, SameThreadExecutor) {
+    override fun startContend() {}
+    override fun stopContend() {}
+
+    fun markOwner(ownerId: String) {
+        notifyOwner(MutexOwner(ownerId, 0, Long.MAX_VALUE, Long.MAX_VALUE))
+    }
+}
+
+/**
+ * Factory that builds a [ControllableContendService] for the given contender
+ * (the locker) and exposes it so tests can drive ownership transitions.
+ */
+private class ControllableFactory : MutexContendServiceFactory {
+    var service: ControllableContendService? = null
+        private set
+
+    override fun createMutexContendService(mutexContender: MutexContender): MutexContendService {
+        val svc = ControllableContendService(mutexContender)
+        service = svc
+        return svc
+    }
+}
+
+class SimbaLockerTest {
+    @Test
+    fun `acquire with timeout throws TimeoutException when ownership never acquired`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        val error = assertThrows<TimeoutException> {
+            locker.acquire(Duration.ofMillis(50))
+        }
+        assertThat(error.message, containsString("Could not acquire"))
+        assertThat(error.message, containsString("within timeout of 50ms"))
+    }
+
+    @Test
+    fun `double acquire with timeout throws IllegalMonitorStateException`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        // The first acquire must genuinely succeed: acquire(timeout) only returns
+        // normally once the contend service is the owner, and start() resets the
+        // owner, so ownership is granted from a helper thread after this thread parks.
+        acquireWithGrantedOwnership(locker, factory)
+
+        val error = assertThrows<IllegalMonitorStateException> {
+            locker.acquire(Duration.ofMillis(50))
+        }
+        assertThat(error.message, containsString("already owns this lock"))
+    }
+
+    @Test
+    fun `acquire without timeout throws IllegalMonitorStateException on double acquire`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        // First acquire must succeed (ownership granted concurrently).
+        acquireWithGrantedOwnership(locker, factory)
+
+        val error = assertThrows<IllegalMonitorStateException> {
+            locker.acquire()
+        }
+        assertThat(error.message, containsString("already owns this lock"))
+    }
+
+    @Test
+    fun `acquire returns when onAcquired unparks the calling thread`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+        val acquired = CountDownLatch(1)
+
+        // Run acquire() on a separate thread; it parks inside LockSupport.park(this).
+        // The main thread then marks ownership, which dispatches to the contender's
+        // notifyOwner -> SimbaLocker.onAcquired -> LockSupport.unpark(owner thread).
+        val ownerThread = Thread {
+            locker.acquire()
+            acquired.countDown()
+        }
+        ownerThread.isDaemon = true
+        ownerThread.start()
+
+        // Wait until the locker's contend service is created and acquire() has parked.
+        // Poll the owner thread until it is WAITING (parked) before marking ownership,
+        // so the unpark is guaranteed to find a parked thread.
+        awaitThreadState(ownerThread, Thread.State.WAITING, 2, TimeUnit.SECONDS)
+        factory.service!!.markOwner(locker.contenderId)
+
+        // The CountDownLatch reaching zero proves acquire() returned after the unpark.
+        assertThat("acquire should return after onAcquired unparks", acquired.await(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun `onAcquired does not throw when no thread owns the locker`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        // Call onAcquired directly without a prior acquire() — OWNER[this] is null,
+        // LockSupport.unpark(null) is a safe no-op.
+        locker.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(locker.contenderId, 0, 100, 200)))
+    }
+
+    @Test
+    fun `close throws IllegalStateException when contend service not running`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        val error = assertThrows<IllegalStateException> { locker.close() }
+        assertThat(error.message, containsString("Cannot stop mutex:[m]"))
+    }
+
+    /**
+     * Makes the locker's first acquire genuinely succeed.
+     *
+     * `acquire(timeout)` only returns normally once `contendService.isOwner` is true,
+     * and `start()` resets the owner, so ownership cannot be pre-granted. A helper
+     * thread waits until the acquirer has parked (TIMED_WAITING, i.e. past start()'s
+     * resetOwner), then grants ownership, which dispatches onAcquired -> unpark ->
+     * isOwner true -> acquire returns.
+     */
+    private fun acquireWithGrantedOwnership(locker: SimbaLocker, factory: ControllableFactory) {
+        val ownerThread = Thread.currentThread()
+        val granter = Thread {
+            awaitThreadState(ownerThread, Thread.State.TIMED_WAITING, 2, TimeUnit.SECONDS)
+            factory.service!!.markOwner(locker.contenderId)
+        }
+        granter.isDaemon = true
+        granter.start()
+        locker.acquire(Duration.ofSeconds(2))
+    }
+
+    private fun awaitThreadState(
+        thread: Thread,
+        state: Thread.State,
+        timeout: Long,
+        unit: TimeUnit
+    ) {
+        val deadline = System.nanoTime() + unit.toNanos(timeout)
+        while (System.nanoTime() < deadline) {
+            if (thread.state == state) return
+            Thread.sleep(10)
+        }
+        throw AssertionError("Thread did not reach state $state within $timeout $unit (was ${thread.state})")
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
@@ -37,8 +37,8 @@ import java.util.concurrent.TimeoutException
 private class ControllableContendService(
     contender: MutexContender
 ) : AbstractMutexContendService(contender, SameThreadExecutor) {
-    override fun startContend() {}
-    override fun stopContend() {}
+    override fun startContend() = Unit
+    override fun stopContend() = Unit
 
     fun markOwner(ownerId: String) {
         notifyOwner(MutexOwner(ownerId, 0, Long.MAX_VALUE, Long.MAX_VALUE))

--- a/simba-core/src/test/kotlin/me/ahoo/simba/schedule/AbstractSchedulerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/schedule/AbstractSchedulerTest.kt
@@ -42,8 +42,8 @@ private class CapturingFactory : MutexContendServiceFactory {
 
 private class NoopContendService(contender: MutexContender) :
     me.ahoo.simba.core.AbstractMutexContendService(contender, me.ahoo.simba.core.SameThreadExecutor) {
-    override fun startContend() {}
-    override fun stopContend() {}
+    override fun startContend() = Unit
+    override fun stopContend() = Unit
 }
 
 /**

--- a/simba-core/src/test/kotlin/me/ahoo/simba/schedule/AbstractSchedulerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/schedule/AbstractSchedulerTest.kt
@@ -109,6 +109,9 @@ class AbstractSchedulerTest {
             assertThat("work should run at least once", latch.await(2, TimeUnit.SECONDS))
             assertThat(counter.get(), greaterThanOrEqualTo(1))
         } finally {
+            // onReleased cancels the scheduled workFuture; NoopContendService.stop() alone
+            // would not, leaving the non-daemon scheduler thread running.
+            contender.onReleased(MutexState(MutexOwner(contender.contenderId, 0, 100, 200), MutexOwner.NONE))
             handle.scheduler.stop()
         }
     }
@@ -133,6 +136,7 @@ class AbstractSchedulerTest {
             assertThat("work should run at least once", latch.await(2, TimeUnit.SECONDS))
             assertThat(counter.get(), greaterThanOrEqualTo(1))
         } finally {
+            contender.onReleased(MutexState(MutexOwner(contender.contenderId, 0, 100, 200), MutexOwner.NONE))
             handle.scheduler.stop()
         }
     }
@@ -181,6 +185,7 @@ class AbstractSchedulerTest {
             assertThat("work should continue after a thrown exception", latch.await(2, TimeUnit.SECONDS))
             assertThat(counter.get(), greaterThanOrEqualTo(2))
         } finally {
+            contender.onReleased(MutexState(MutexOwner(contender.contenderId, 0, 100, 200), MutexOwner.NONE))
             handle.scheduler.stop()
         }
     }

--- a/simba-core/src/test/kotlin/me/ahoo/simba/schedule/AbstractSchedulerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/schedule/AbstractSchedulerTest.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.schedule
+
+import me.ahoo.simba.core.MutexContendServiceFactory
+import me.ahoo.simba.core.MutexContender
+import me.ahoo.simba.core.MutexOwner
+import me.ahoo.simba.core.MutexState
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.greaterThanOrEqualTo
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Factory exposing the created contender so tests can drive onAcquired/onReleased.
+ */
+private class CapturingFactory : MutexContendServiceFactory {
+    var contender: MutexContender? = null
+        private set
+
+    override fun createMutexContendService(mutexContender: MutexContender): me.ahoo.simba.core.MutexContendService {
+        contender = mutexContender
+        // Return a no-op contend service; tests call contender.onAcquired directly
+        return NoopContendService(mutexContender)
+    }
+}
+
+private class NoopContendService(contender: MutexContender) :
+    me.ahoo.simba.core.AbstractMutexContendService(contender, me.ahoo.simba.core.SameThreadExecutor) {
+    override fun startContend() {}
+    override fun stopContend() {}
+}
+
+/**
+ * Builds an [AbstractScheduler] whose [AbstractScheduler.config] / [AbstractScheduler.worker] / [AbstractScheduler.work]
+ * are supplied as already-initialized locals, avoiding the super-ctor init-order footgun.
+ * Captures the [AbstractScheduler.WorkContender] created in the constructor so tests can drive it directly.
+ *
+ * Returns the pair (scheduler, contender). Mirrors the anonymous-object pattern used by
+ * [MutexContendServiceSpec.schedule].
+ */
+private class SchedulerHandle(
+    val scheduler: AbstractScheduler,
+    val contender: AbstractScheduler.WorkContender
+)
+
+private fun newScheduler(
+    mutex: String,
+    config: ScheduleConfig,
+    worker: String,
+    latch: CountDownLatch,
+    counter: AtomicInteger,
+    shouldThrow: Boolean = false
+): SchedulerHandle {
+    val factory = CapturingFactory()
+    // locals captured by the closure are fully initialized before the object is created,
+    // so `config`/`worker` getters read non-null values during the super-ctor.
+    val scheduler = object : AbstractScheduler(mutex, factory) {
+        override val config: ScheduleConfig get() = config
+        override val worker: String get() = worker
+        override fun work() {
+            // Advance the counter FIRST so the throw-once guard (firstRun) can ever
+            // become false; otherwise the throwing run never increments and every
+            // subsequent run would throw forever.
+            val firstRun = counter.getAndIncrement() == 0
+            if (shouldThrow && firstRun) {
+                throw IllegalStateException("work-boom")
+            }
+            latch.countDown()
+        }
+    }
+    val contender = factory.contender!! as AbstractScheduler.WorkContender
+    return SchedulerHandle(scheduler, contender)
+}
+
+class AbstractSchedulerTest {
+    @Test
+    fun `onAcquired schedules work at fixed rate`() {
+        val latch = CountDownLatch(1)
+        val counter = AtomicInteger(0)
+        val handle = newScheduler(
+            mutex = "m",
+            config = ScheduleConfig.rate(Duration.ofMillis(0), Duration.ofMillis(50)),
+            worker = "rate-worker",
+            latch = latch,
+            counter = counter
+        )
+        val contender = handle.contender
+
+        try {
+            handle.scheduler.start()
+            contender.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(contender.contenderId, 0, 100, 200)))
+
+            assertThat("work should run at least once", latch.await(2, TimeUnit.SECONDS))
+            assertThat(counter.get(), greaterThanOrEqualTo(1))
+        } finally {
+            handle.scheduler.stop()
+        }
+    }
+
+    @Test
+    fun `onAcquired schedules work with fixed delay`() {
+        val latch = CountDownLatch(1)
+        val counter = AtomicInteger(0)
+        val handle = newScheduler(
+            mutex = "m",
+            config = ScheduleConfig.delay(Duration.ofMillis(0), Duration.ofMillis(50)),
+            worker = "delay-worker",
+            latch = latch,
+            counter = counter
+        )
+        val contender = handle.contender
+
+        try {
+            handle.scheduler.start()
+            contender.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(contender.contenderId, 0, 100, 200)))
+
+            assertThat("work should run at least once", latch.await(2, TimeUnit.SECONDS))
+            assertThat(counter.get(), greaterThanOrEqualTo(1))
+        } finally {
+            handle.scheduler.stop()
+        }
+    }
+
+    @Test
+    fun `onReleased cancels scheduled work without throwing`() {
+        val latch = CountDownLatch(1)
+        val counter = AtomicInteger(0)
+        val handle = newScheduler(
+            mutex = "m",
+            config = ScheduleConfig.rate(Duration.ofMillis(0), Duration.ofMillis(50)),
+            worker = "release-worker",
+            latch = latch,
+            counter = counter
+        )
+        val contender = handle.contender
+
+        try {
+            handle.scheduler.start()
+            contender.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(contender.contenderId, 0, 100, 200)))
+            // cancel the scheduled future
+            contender.onReleased(MutexState(MutexOwner(contender.contenderId, 0, 100, 200), MutexOwner.NONE))
+        } finally {
+            handle.scheduler.stop()
+        }
+    }
+
+    @Test
+    fun `safeWork swallows work exception and keeps scheduling`() {
+        val latch = CountDownLatch(2)
+        val counter = AtomicInteger(0)
+        val handle = newScheduler(
+            mutex = "m",
+            config = ScheduleConfig.rate(Duration.ofMillis(0), Duration.ofMillis(20)),
+            worker = "throw-worker",
+            latch = latch,
+            counter = counter,
+            shouldThrow = true
+        )
+        val contender = handle.contender
+
+        try {
+            handle.scheduler.start()
+            contender.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(contender.contenderId, 0, 100, 200)))
+
+            assertThat("work should continue after a thrown exception", latch.await(2, TimeUnit.SECONDS))
+            assertThat(counter.get(), greaterThanOrEqualTo(2))
+        } finally {
+            handle.scheduler.stop()
+        }
+    }
+
+    @Test
+    fun `running reflects contend service status`() {
+        val latch = CountDownLatch(1)
+        val counter = AtomicInteger(0)
+        val handle = newScheduler(
+            mutex = "m",
+            config = ScheduleConfig.rate(Duration.ofMillis(0), Duration.ofMillis(50)),
+            worker = "running-worker",
+            latch = latch,
+            counter = counter
+        )
+
+        assertThat(handle.scheduler.running, equalTo(false))
+        handle.scheduler.start()
+        assertThat(handle.scheduler.running, equalTo(true))
+        handle.scheduler.stop()
+        assertThat(handle.scheduler.running, equalTo(false))
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/schedule/ScheduleConfigTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/schedule/ScheduleConfigTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.schedule
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class ScheduleConfigTest {
+    @Test
+    fun `rate factory sets FIXED_RATE strategy`() {
+        val config = ScheduleConfig.rate(Duration.ofMillis(10), Duration.ofMillis(100))
+
+        assertThat(config.strategy, equalTo(ScheduleConfig.Strategy.FIXED_RATE))
+        assertThat(config.initialDelay, equalTo(Duration.ofMillis(10)))
+        assertThat(config.period, equalTo(Duration.ofMillis(100)))
+    }
+
+    @Test
+    fun `delay factory sets FIXED_DELAY strategy`() {
+        val config = ScheduleConfig.delay(Duration.ofMillis(10), Duration.ofMillis(100))
+
+        assertThat(config.strategy, equalTo(ScheduleConfig.Strategy.FIXED_DELAY))
+    }
+
+    @Test
+    fun `data class equals and copy`() {
+        val config = ScheduleConfig.rate(Duration.ofMillis(10), Duration.ofMillis(100))
+        val copy = config.copy()
+
+        assertThat(copy, equalTo(config))
+        assertThat(copy, not(sameInstance(config)))
+    }
+
+    @Test
+    fun `data class component destructuring`() {
+        val config = ScheduleConfig.delay(Duration.ofMillis(5), Duration.ofMillis(50))
+
+        val (strategy, initialDelay, period) = config
+        assertThat(strategy, equalTo(ScheduleConfig.Strategy.FIXED_DELAY))
+        assertThat(initialDelay, equalTo(Duration.ofMillis(5)))
+        assertThat(period, equalTo(Duration.ofMillis(50)))
+    }
+
+    @Test
+    fun `Strategy enum has FIXED_DELAY then FIXED_RATE in order`() {
+        val values = ScheduleConfig.Strategy.values()
+
+        assertThat(values.size, equalTo(2))
+        assertThat(values[0], equalTo(ScheduleConfig.Strategy.FIXED_DELAY))
+        assertThat(values[1], equalTo(ScheduleConfig.Strategy.FIXED_RATE))
+    }
+}

--- a/simba-core/src/test/kotlin/me/ahoo/simba/util/ThreadsTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/util/ThreadsTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.util
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+
+class ThreadsTest {
+    @Test
+    fun `defaultFactory creates non-daemon threads`() {
+        val factory = Threads.defaultFactory("domain")
+
+        val thread = factory.newThread { }
+
+        assertThat(thread.isDaemon, `is`(false))
+    }
+
+    @Test
+    fun `defaultFactory names threads with domain counter`() {
+        val factory = Threads.defaultFactory("worker")
+
+        val first = factory.newThread { }
+        val second = factory.newThread { }
+
+        assertThat(first.name, equalTo("worker-0"))
+        assertThat(second.name, equalTo("worker-1"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds **13 focused unit test files** (+ 1 shared `TestDoubles.kt`) to `simba-core`, raising **direct** unit-test coverage of the most foundational module. No production code changes; no external services (Redis/MySQL/Zookeeper) required — all tests run in plain `./gradlew simba-core:test`.

## Coverage improvement (direct unit tests only)

| Package | Before | After (Instr) | Branch |
|---|---|---|---|
| `me.ahoo.simba` (Simba, SimbaException) | 0% | **100%** | n/a (no branches) |
| `me.ahoo.simba.core` | ~80% (indirect) | **90%** | **98%** |
| `me.ahoo.simba.locker` (SimbaLocker) | partial | **94%** | **100%** |
| `me.ahoo.simba.schedule` | partial | **94%** | 50% |
| `me.ahoo.simba.util` (Threads) | 100% | **100%** | n/a |

The standout win is **branch coverage**: the aggregate was ~51.4% (the weakest metric). The state machine, value-type predicates, and contender dispatch are now comprehensively covered — `core` branch coverage hits **98%**, `locker` hits **100%**.

## What's tested

- **State machine** (`AbstractMutexRetrievalService`): CAS guards on `start`/`stop`, try/catch rollback on `startContend`/`stopContend` failure, `safeNotifyOwner` swallowing retriever exceptions while preserving the order-of-assignment contract, `close` delegation, `resetOwner` on restart.
- **Value types**: `MutexState` (all predicate combos + data-class contract), `MutexOwner` (time-boundary `>`/`>=` edges, `NONE` constant), `ContendPeriod` (negative-clamp, owner/contender dispatch, `transition==0` branch).
- **Contender dispatch**: `MutexContender.notifyOwner` default impl — unchanged early-return, onAcquired, onReleased, role-swap.
- **Locker** (`SimbaLocker`): `acquire`/`acquire(timeout)` CAS, `TimeoutException` branch, park/unpark happy path via thread-state polling, `IllegalMonitorStateException` on double-acquire, `close`.
- **Scheduler** (`AbstractScheduler`): `FIXED_RATE`/`FIXED_DELAY` strategy branch, `onAcquired` guard, `onReleased` cancel, `safeWork` exception-swallowing with continued scheduling.
- **Utilities**: `ContenderIdGenerator` (UUID/HOST format + counter), `ScheduleConfig` (factories + enum), `Threads` (daemon=false, name format), `Simba`/`SimbaException` (constants + 5 constructors).

## Test design

- **Fakes over mocks**: shared `FixedClockOwner`, `FakeMutexContender`, `FakeMutexContendService`, `SameThreadExecutor` — matches the TCK convention (`MutexContendServiceSpec`), no MockK used.
- **Deterministic time**: `FixedClockOwner` overrides `currentAt` for all time-dependent logic.
- **Deterministic async**: `SameThreadExecutor` makes `notifyOwner`'s `CompletableFuture.runAsync` run inline.
- **Concurrency safety**: `SimbaLocker` happy path polls `Thread.State.WAITING` before unparking (no flaky `Thread.sleep`); `AbstractScheduler` always `stop()`s in `finally`.

## Verification

- `./gradlew simba-core:test` — **99 tests, all pass** (14 test classes)
- `./gradlew simba-core:detekt` — clean
- `SimbaLockerTest` and `AbstractSchedulerTest` verified non-flaky across multiple `--rerun-tasks` runs

Design doc: `docs/superpowers/specs/2026-07-07-simba-core-test-coverage-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-07-simba-core-test-coverage.md`