### PR TITLE
fix(example): align application.yaml with Redis backend dependencies

### DIFF
--- a/simba-example/src/main/resources/application.yaml
+++ b/simba-example/src/main/resources/application.yaml
@@ -1,14 +1,14 @@
 simba:
-  jdbc:
-    enabled: true
-#  redis:
+#  jdbc:
 #    enabled: true
+  redis:
+    enabled: true
 
 spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/simba_db
-    username: root
-    password: root
+#  datasource:
+#    url: jdbc:mysql://localhost:3306/simba_db
+#    username: root
+#    password: root
   task:
     scheduling:
       pool:


### PR DESCRIPTION
## Problem

`simba-example` had a backend drift between its build dependencies and runtime configuration:

- **`build.gradle.kts`** (`:36-37`): depends on the **Redis** backend — `simba-spring-redis` + `spring-boot-starter-data-redis`. JDBC dependencies are commented out (`:32-34`).
- **`application.yaml`** (before): enabled `simba.jdbc.enabled: true` and commented out `redis.enabled`.

Because the JDBC `MutexContendServiceFactory` bean could never be created (no `simba-jdbc` on the classpath), `ExampleApp` would fail to start with a missing `MutexContendServiceFactory` bean.

## Fix

Enable `simba.redis.enabled: true` and comment out the `jdbc` / `datasource` blocks in `application.yaml`, so the config matches the Redis backend that the module actually depends on.

```diff
 simba:
-  jdbc:
-    enabled: true
-#  redis:
-#    enabled: true
+#  jdbc:
+#    enabled: true
+  redis:
+    enabled: true

 spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/simba_db
-    username: root
-    password: root
+#  datasource:
+#    url: jdbc:mysql://localhost:3306/simba_db
+#    username: root
+#    password: root
```

The commented JDBC/datasource blocks are intentionally retained (mirroring how `build.gradle.kts` keeps its JDBC deps commented) so contributors can switch backends by flipping comments in both files.

## Runtime wiring (verified by reading the auto-config)

With `redis.enabled=true` + `spring-boot-starter-data-redis` on the classpath + `spring.data.redis.url` set, `SimbaSpringRedisAutoConfiguration` correctly assembles the `MutexContendServiceFactory` bean (`@ConditionalOnSimbaRedisEnabled` → `@ConditionalOnClass(StringRedisTemplate)` → `@ConditionalOnBean(StringRedisTemplate)`), which `ExampleApp` injects.

`ExampleApp.java` itself is backend-agnostic — it only depends on the core `MutexContendServiceFactory` and `SimbaLocker` abstractions.

## Verification
- ✅ `./gradlew :simba-example:classes :simba-example:compileTestJava` — BUILD SUCCESSFUL
- ✅ `git diff --check` — no whitespace errors

A full runtime smoke test requires a Redis instance on `localhost:6379` (the configured `spring.data.redis.url`).

> Flagged originally during the wiki optimization in #422 as out-of-scope; this PR addresses it at the code level.