### PR TITLE
fix: resolve mutex notification races and executor leaks from code review

### DIFF
--- a/simba-core/src/main/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalService.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalService.kt
@@ -44,6 +44,13 @@ abstract class AbstractMutexRetrievalService protected constructor(
     override var mutexState: MutexState = MutexState.NONE
         protected set
 
+    /**
+     * Serializes the read-before/write/notify sequence in [safeNotifyOwner]:
+     * without it, two concurrent notifications can both observe a stale `before`
+     * owner and dispatch duplicate owner-change events for one transition.
+     */
+    private val notifyLock = Any()
+
     protected fun resetOwner() {
         mutexState = MutexState.NONE
     }
@@ -78,9 +85,11 @@ abstract class AbstractMutexRetrievalService protected constructor(
              * Concurrency issues.
              * Order of assignment is very important.
              */
-            val newState = MutexState(afterOwner, newOwner)
-            mutexState = newState
-            retriever.notifyOwner(newState)
+            synchronized(notifyLock) {
+                val newState = MutexState(afterOwner, newOwner)
+                mutexState = newState
+                retriever.notifyOwner(newState)
+            }
         } catch (throwable: Throwable) {
             log.error(throwable) {
                 "safeNotifyOwner error - mutex:[$retriever] - newOwner:[$newOwner]"

--- a/simba-core/src/main/kotlin/me/ahoo/simba/locker/SimbaLocker.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/locker/SimbaLocker.kt
@@ -63,7 +63,22 @@ class SimbaLocker(
     override fun acquire() {
         if (OWNER.compareAndSet(this, null, Thread.currentThread())) {
             contendService.start()
-            LockSupport.park(this)
+            var interrupted = false
+            /*
+             * park can also return spuriously or on interruption;
+             * only acquiring ownership ends the wait. Interruption does not cancel
+             * the acquire (j.u.c convention): the flag is consumed for parking and
+             * restored on exit.
+             */
+            while (!contendService.isOwner) {
+                LockSupport.park(this)
+                if (Thread.interrupted()) {
+                    interrupted = true
+                }
+            }
+            if (interrupted) {
+                Thread.currentThread().interrupt()
+            }
         } else {
             throw IllegalMonitorStateException("Thread[${OWNER.get(this)}] already owns this lock[$mutex].")
         }
@@ -73,7 +88,21 @@ class SimbaLocker(
     override fun acquire(timeout: Duration) {
         if (OWNER.compareAndSet(this, null, Thread.currentThread())) {
             contendService.start()
-            LockSupport.parkNanos(this, timeout.toNanos())
+            val deadline = System.nanoTime() + timeout.toNanos()
+            var interrupted = false
+            while (!contendService.isOwner) {
+                val remaining = deadline - System.nanoTime()
+                if (remaining <= 0) {
+                    break
+                }
+                LockSupport.parkNanos(this, remaining)
+                if (Thread.interrupted()) {
+                    interrupted = true
+                }
+            }
+            if (interrupted) {
+                Thread.currentThread().interrupt()
+            }
             if (!contendService.isOwner) {
                 throw TimeoutException(
                     "Could not acquire [$contenderId]@mutex:[$mutex] within timeout of ${timeout.toMillis()}ms"

--- a/simba-core/src/main/kotlin/me/ahoo/simba/schedule/AbstractScheduler.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/schedule/AbstractScheduler.kt
@@ -35,8 +35,9 @@ abstract class AbstractScheduler(
         private val log = LoggerFactory.getLogger(AbstractScheduler::class.java)
     }
 
+    private val workContender = WorkContender(mutex)
     private val contendService: MutexContendService =
-        contendServiceFactory.createMutexContendService(WorkContender(mutex))
+        contendServiceFactory.createMutexContendService(workContender)
 
     protected abstract val config: ScheduleConfig
     protected abstract val worker: String
@@ -46,19 +47,23 @@ abstract class AbstractScheduler(
     }
 
     fun stop() {
-        contendService.stop()
+        try {
+            contendService.stop()
+        } finally {
+            workContender.shutdown()
+        }
     }
 
     val running: Boolean
         get() = contendService.running
 
     inner class WorkContender(mutex: String) : AbstractMutexContender(mutex) {
-        private val scheduledThreadPoolExecutor: ScheduledThreadPoolExecutor = ScheduledThreadPoolExecutor(
-            1,
-            defaultFactory(
-                worker
-            )
-        )
+        /**
+         * Created lazily on first acquisition and shut down by [shutdown] on scheduler stop,
+         * so a stopped (or never-started) scheduler holds no threads; a restart recreates it.
+         */
+        @Volatile
+        private var scheduledThreadPoolExecutor: ScheduledThreadPoolExecutor? = null
 
         @Volatile
         private var workFuture: ScheduledFuture<*>? = null
@@ -68,15 +73,16 @@ abstract class AbstractScheduler(
             if (workFuture == null || workFuture!!.isDone) {
                 val initialDelay = config.initialDelay.toMillis()
                 val period = config.period.toMillis()
+                val executor = ensureExecutor()
                 workFuture = if (ScheduleConfig.Strategy.FIXED_RATE == config.strategy) {
-                    scheduledThreadPoolExecutor.scheduleAtFixedRate(
+                    executor.scheduleAtFixedRate(
                         this::safeWork,
                         initialDelay,
                         period,
                         TimeUnit.MILLISECONDS
                     )
                 } else {
-                    scheduledThreadPoolExecutor.scheduleWithFixedDelay(
+                    executor.scheduleWithFixedDelay(
                         this::safeWork,
                         initialDelay,
                         period,
@@ -89,6 +95,17 @@ abstract class AbstractScheduler(
         override fun onReleased(mutexState: MutexState) {
             super.onReleased(mutexState)
             workFuture?.cancel(true)
+        }
+
+        private fun ensureExecutor(): ScheduledThreadPoolExecutor {
+            return scheduledThreadPoolExecutor
+                ?: ScheduledThreadPoolExecutor(1, defaultFactory(worker))
+                    .also { scheduledThreadPoolExecutor = it }
+        }
+
+        fun shutdown() {
+            scheduledThreadPoolExecutor?.shutdown()
+            scheduledThreadPoolExecutor = null
         }
 
         @Suppress("TooGenericExceptionCaught")

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
@@ -148,4 +148,27 @@ class AbstractMutexRetrievalServiceTest {
         assertThat(service.mutexState, equalTo(MutexState.NONE))
         service.stop()
     }
+
+    @Test
+    fun `concurrent duplicate owner notifications dispatch onAcquired at most once`() {
+        // The read->write window inside safeNotifyOwner is nanoseconds wide, so a single
+        // barrier-paired pair rarely interleaves; thousands of attempts make hitting the
+        // window a statistical certainty before the fix, while the fix passes deterministically.
+        for (attempt in 0 until 5000) {
+            val contender = ConcurrentCountingContender("m", "c1-$attempt")
+            val service = FakeMutexContendService(contender, BarrierPairExecutor())
+            val selfOwner = MutexOwner(contender.contenderId, 0, Long.MAX_VALUE, Long.MAX_VALUE)
+
+            val first = service.publishOwner(selfOwner)
+            val second = service.publishOwner(selfOwner)
+            first.join()
+            second.join()
+
+            assertThat(
+                "attempt [$attempt]: duplicate onAcquired dispatched for a single NONE->self transition",
+                contender.acquiredCount.get(),
+                equalTo(1)
+            )
+        }
+    }
 }

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt
@@ -14,7 +14,11 @@
 package me.ahoo.simba.core
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
 
 /**
  * [MutexOwner] with a fixed [currentAt] for deterministic time-based tests.
@@ -63,6 +67,40 @@ object SameThreadExecutor : Executor {
     override fun execute(command: Runnable) {
         command.run()
     }
+}
+
+/**
+ * Executor that pairs two submitted tasks at a barrier and then runs each on its
+ * own thread, so both notifications enter [AbstractMutexRetrievalService.safeNotifyOwner]
+ * at the same instant — a deterministic stand-in for a multi-threaded handleExecutor
+ * (the production default is ForkJoinPool.commonPool).
+ */
+class BarrierPairExecutor : Executor {
+    private val barrier = CyclicBarrier(2)
+
+    override fun execute(command: Runnable) {
+        thread(isDaemon = true) {
+            runCatching { barrier.await(10, TimeUnit.SECONDS) }
+            command.run()
+        }
+    }
+}
+
+/**
+ * [MutexContender] that counts [onAcquired] calls atomically.
+ * Unlike [FakeMutexContender] this is safe under concurrent notification.
+ */
+class ConcurrentCountingContender(
+    override val mutex: String,
+    override val contenderId: String
+) : MutexContender {
+    val acquiredCount = AtomicInteger()
+
+    override fun onAcquired(mutexState: MutexState) {
+        acquiredCount.incrementAndGet()
+    }
+
+    override fun onReleased(mutexState: MutexState) = Unit
 }
 
 /**

--- a/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
@@ -22,12 +22,14 @@ import me.ahoo.simba.core.MutexState
 import me.ahoo.simba.core.SameThreadExecutor
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import kotlin.concurrent.thread
 
 /**
  * Controllable contend service bound to the contender passed by the factory.
@@ -137,6 +139,32 @@ class SimbaLockerTest {
         // Call onAcquired directly without a prior acquire() — OWNER[this] is null,
         // LockSupport.unpark(null) is a safe no-op.
         locker.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(locker.contenderId, 0, 100, 200)))
+    }
+
+    @Test
+    fun `acquire does not return without ownership when interrupted while parked`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+        val returned = CountDownLatch(1)
+
+        val ownerThread = thread(isDaemon = true) {
+            locker.acquire()
+            returned.countDown()
+        }
+
+        // acquire() parks waiting for ownership; the service never grants it
+        awaitThreadState(ownerThread, Thread.State.WAITING, 2, TimeUnit.SECONDS)
+        ownerThread.interrupt()
+
+        assertThat(
+            "acquire() returned without ownership after interrupt",
+            returned.await(500, TimeUnit.MILLISECONDS),
+            equalTo(false)
+        )
+
+        // release the parked thread: grant ownership so acquire() returns and the thread ends
+        factory.service!!.markOwner(locker.contenderId)
+        assertThat("acquire() should return once ownership is granted", returned.await(2, TimeUnit.SECONDS))
     }
 
     @Test

--- a/simba-core/src/test/kotlin/me/ahoo/simba/schedule/AbstractSchedulerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/schedule/AbstractSchedulerTest.kt
@@ -208,4 +208,43 @@ class AbstractSchedulerTest {
         handle.scheduler.stop()
         assertThat(handle.scheduler.running, equalTo(false))
     }
+
+    @Test
+    fun `stop terminates the work scheduler thread`() {
+        val latch = CountDownLatch(1)
+        val counter = AtomicInteger(0)
+        val handle = newScheduler(
+            mutex = "m",
+            config = ScheduleConfig.rate(Duration.ofMillis(0), Duration.ofMillis(50)),
+            worker = "shutdown-worker",
+            latch = latch,
+            counter = counter
+        )
+
+        handle.scheduler.start()
+        // drive acquisition directly so the work executor thread is created and scheduled
+        handle.contender.onAcquired(
+            MutexState(MutexOwner.NONE, MutexOwner(handle.contender.contenderId, 0, 100, 200))
+        )
+        assertThat("work should run at least once", latch.await(2, TimeUnit.SECONDS))
+
+        handle.scheduler.stop()
+
+        assertThat(
+            "work scheduler thread should terminate after stop",
+            awaitThreadGone("shutdown-worker-0", 2, TimeUnit.SECONDS),
+            equalTo(true)
+        )
+    }
+
+    private fun awaitThreadGone(name: String, timeout: Long, unit: TimeUnit): Boolean {
+        val deadline = System.nanoTime() + unit.toNanos(timeout)
+        while (System.nanoTime() < deadline) {
+            if (Thread.getAllStackTraces().keys.none { it.name == name }) {
+                return true
+            }
+            Thread.sleep(20)
+        }
+        return Thread.getAllStackTraces().keys.none { it.name == name }
+    }
 }

--- a/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/redis/SimbaSpringRedisAutoConfiguration.kt
+++ b/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/redis/SimbaSpringRedisAutoConfiguration.kt
@@ -51,7 +51,7 @@ class SimbaSpringRedisAutoConfiguration(private val redisProperties: RedisProper
         return container
     }
 
-    @Bean
+    @Bean(destroyMethod = "close")
     @ConditionalOnMissingBean
     @ConditionalOnBean(StringRedisTemplate::class)
     fun redisMutexContendServiceFactory(

--- a/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceFactory.kt
+++ b/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceFactory.kt
@@ -26,6 +26,9 @@ import java.util.concurrent.ScheduledExecutorService
 /**
  * Spring Redis Mutex Contend Service Factory .
  *
+ * The factory owns its [scheduledExecutorService] lifecycle: closing it shuts the executor
+ * down, so callers sharing an executor across factories should pass a dedicated one.
+ *
  * @author ahoo wang
  */
 class SpringRedisMutexContendServiceFactory(
@@ -35,7 +38,7 @@ class SpringRedisMutexContendServiceFactory(
     private val listenerContainer: RedisMessageListenerContainer,
     private val handleExecutor: Executor = ForkJoinPool.commonPool(),
     private val scheduledExecutorService: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
-) : MutexContendServiceFactory {
+) : MutexContendServiceFactory, AutoCloseable {
     override fun createMutexContendService(mutexContender: MutexContender): MutexContendService {
         return SpringRedisMutexContendService(
             mutexContender,
@@ -46,5 +49,9 @@ class SpringRedisMutexContendServiceFactory(
             listenerContainer,
             scheduledExecutorService
         )
+    }
+
+    override fun close() {
+        scheduledExecutorService.shutdown()
     }
 }

--- a/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceFactoryTest.kt
+++ b/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceFactoryTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.spring.redis
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import java.time.Duration
+import java.util.concurrent.Executors
+
+class SpringRedisMutexContendServiceFactoryTest {
+    @Test
+    fun `close shuts down the scheduled executor service`() {
+        val scheduledExecutorService = Executors.newScheduledThreadPool(1)
+        val factory = SpringRedisMutexContendServiceFactory(
+            ttl = Duration.ofSeconds(10),
+            transition = Duration.ofSeconds(6),
+            redisTemplate = org.springframework.data.redis.core.StringRedisTemplate(),
+            listenerContainer = RedisMessageListenerContainer(),
+            scheduledExecutorService = scheduledExecutorService
+        )
+
+        factory.close()
+
+        assertThat(scheduledExecutorService.isShutdown, equalTo(true))
+    }
+}

--- a/simba-zookeeper/src/main/kotlin/me/ahoo/simba/zookeeper/ZookeeperMutexContendService.kt
+++ b/simba-zookeeper/src/main/kotlin/me/ahoo/simba/zookeeper/ZookeeperMutexContendService.kt
@@ -48,6 +48,14 @@ class ZookeeperMutexContendService(
     }
 
     override fun isLeader() {
+        if (!status.isActive) {
+            /*
+             * A late callback delivered after stop (INITIAL), or racing with stop (STOPPING),
+             * must not revive ownership: notLeader() is still allowed during STOPPING because
+             * CloseMode.NOTIFY_LEADER delivers the release notification while stopping.
+             */
+            return
+        }
         notifyOwner(MutexOwner(contenderId))
     }
 

--- a/simba-zookeeper/src/test/kotlin/me/ahoo/simba/zookeeper/ZookeeperMutexContendServiceTest.kt
+++ b/simba-zookeeper/src/test/kotlin/me/ahoo/simba/zookeeper/ZookeeperMutexContendServiceTest.kt
@@ -13,15 +13,41 @@
 package me.ahoo.simba.zookeeper
 
 import me.ahoo.simba.core.MutexContendServiceFactory
+import me.ahoo.simba.core.MutexContender
+import me.ahoo.simba.core.MutexOwner
+import me.ahoo.simba.core.MutexRetrievalService.Status
+import me.ahoo.simba.core.MutexState
 import me.ahoo.simba.test.MutexContendServiceSpec
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.retry.RetryNTimes
 import org.apache.curator.test.TestingServer
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.Executor
 import java.util.concurrent.ForkJoinPool
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Thread-safe counting contender: LeaderLatch callbacks arrive on the Curator
+ * EventThread while assertions poll from the test thread.
+ */
+private class CountingContender(
+    override val mutex: String,
+    override val contenderId: String
+) : MutexContender {
+    val acquiredCount = AtomicInteger()
+
+    override fun onAcquired(mutexState: MutexState) {
+        acquiredCount.incrementAndGet()
+    }
+
+    override fun onReleased(mutexState: MutexState) = Unit
+}
 
 /**
  * @author ahoo wang
@@ -50,5 +76,38 @@ internal class ZookeeperMutexContendServiceTest : MutexContendServiceSpec() {
         if (this::testingServer.isInitialized) {
             testingServer.stop()
         }
+    }
+
+    @Test
+    fun `late isLeader callback after stop must not revive ownership`() {
+        val mutex = "late-is-leader-${System.currentTimeMillis()}"
+        val contender = CountingContender(mutex, "late-callback-contender")
+        // synchronous handleExecutor: notifyOwner applies inline on the calling thread
+        val directExecutor = Executor { it.run() }
+        val contendService = ZookeeperMutexContendService(contender, directExecutor, curatorFramework)
+
+        contendService.start()
+
+        // the sole contender genuinely becomes leader shortly after start
+        val deadline = System.currentTimeMillis() + 10_000
+        while (contender.acquiredCount.get() == 0 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50)
+        }
+        assertThat("sole contender should become leader", contender.acquiredCount.get(), equalTo(1))
+
+        contendService.stop()
+        assertThat(contendService.status, equalTo(Status.INITIAL))
+        assertThat("state after stop should be owner-less", contendService.afterOwner, equalTo(MutexOwner.NONE))
+
+        // simulate a LeaderLatch callback dispatched by the Curator EventThread
+        // racing with close() and arriving after stop completed
+        contendService.isLeader()
+
+        assertThat(
+            "late isLeader must be ignored after stop",
+            contender.acquiredCount.get(),
+            equalTo(1)
+        )
+        assertThat("mutexState must stay owner-less after stop", contendService.afterOwner, equalTo(MutexOwner.NONE))
     }
 }


### PR DESCRIPTION
## Summary

Five fixes from a full code review of the race and resource-lifecycle findings. Every fix was developed test-first: each regression test was confirmed **RED on the unfixed code** before the implementation was touched (one early test draft turned out to be a false reproduction — GREEN pre-fix — and was hardened before proceeding), then GREEN after the fix.

### Race fixes

1. **core — duplicate `onAcquired` dispatch** (`AbstractMutexRetrievalService`): the read-before/write/notify sequence in `safeNotifyOwner` was not atomic. Two concurrent notifications on a multi-threaded `handleExecutor` (production default is `ForkJoinPool.commonPool()`) could both observe a stale `before` owner and each dispatch `onAcquired` for a single ownership transition — downstream, `WorkContender` could double-schedule periodic work, breaking local mutual exclusion. The sequence is now serialized with a private lock, dispatch included, so state and notification order stay consistent even under out-of-order task execution.
   - Regression test: 5000 barrier-paired duplicate notifications — RED ×3 pre-fix (hits at attempts 114/1035/3180), deterministic GREEN ×3 post-fix.

2. **zookeeper — late `isLeader()` revival**: a LeaderLatch callback delivered after `stop()` (INITIAL) or racing with it (STOPPING) revived `mutexState` and fired `onAcquired` on a stopped service (e.g. unparking an abandoned `SimbaLocker` waiter). `isLeader()` now returns early when status is not active. `notLeader()` is deliberately **not** guarded: `CloseMode.NOTIFY_LEADER` delivers the legitimate release notification during STOPPING, which the TCK `releasedFuture.join()` assertions depend on — full ZK TCK stays green.
   - Regression test uses the embedded Curator TestingServer and simulates the late EventThread dispatch.

3. **locker — bare `LockSupport.park`**: `acquire()` parked once without re-checking ownership, so a spurious wakeup or thread interrupt made it return while the contender did **not** own the mutex — callers entered their critical section unlocked. `acquire()`/`acquire(timeout)` now loop on `contendService.isOwner`. Interruption does not cancel the wait (j.u.c `ReentrantLock.lock()` convention): the flag is consumed for parking and restored on exit. Public API unchanged.

### Executor lifecycle fixes

4. **core — `AbstractScheduler` thread leak**: `WorkContender`'s single-thread executor was created eagerly and never shut down; every stopped or discarded scheduler leaked one non-daemon thread and kept JVMs from exiting. The executor is now created lazily on first acquisition and shut down in `stop()`'s `finally`; a restart recreates it on the next acquisition. `onReleased` still only cancels, so leadership loss during normal operation keeps re-acquisition possible.
   - Regression test asserts the worker thread terminates after stop (deterministic RED pre-fix — non-daemon thread never dies).

5. **redis — factory executor leak**: `SpringRedisMutexContendServiceFactory`'s default scheduled executor was never closed by anyone, blocking JVM exit in non-web apps and leaking a thread per context refresh. The factory now implements `AutoCloseable` (ownership documented: callers sharing an executor should pass a dedicated one), and the starter bean declares `destroyMethod = "close"`.

## Test plan

- [x] `simba-core:check` (all new regression tests + full suite)
- [x] `simba-zookeeper:check` (TCK + late-callback regression)
- [x] `simba-spring-redis:check` (close regression + existing suite, local Redis)
- [x] `simba-spring-boot-starter:check`
- [ ] `simba-jdbc:check` — not run locally (no MySQL available); shared core paths changed, CI run recommended