### PR TITLE
fix(jdbc): keep SimbaException wrapping and guard post-stop rescheduling

### DIFF
--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
@@ -57,6 +57,17 @@ class JdbcMutexContendService(
         log.debug {
             "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] - nextDelay:[$nextDelay]."
         }
+        if (!status.isActive) {
+            /*
+             * A contend task can still be in flight when stop() shuts the executor down
+             * (JDBC calls are not interruptible); scheduling on from that path would throw
+             * RejectedExecutionException that nobody observes.
+             */
+            log.warn {
+                "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] is not active[$status]."
+            }
+            return
+        }
         contendScheduledFuture = executorService!!.schedule({ safeHandleContend() }, nextDelay, TimeUnit.MILLISECONDS)
     }
 

--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt
@@ -209,11 +209,11 @@ class JdbcMutexOwnerRepository(private val dataSource: DataSource) : MutexOwnerR
                     mutexOwner
                 } catch (throwable: Throwable) {
                     connection.rollback()
-                    throw SimbaException(throwable.message!!, throwable)
+                    throw SimbaException(throwable)
                 }
             }
         } catch (sqlException: SQLException) {
-            throw SimbaException(sqlException.message!!, sqlException)
+            throw SimbaException(sqlException)
         }
     }
 

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.jdbc
+
+import me.ahoo.simba.core.AbstractMutexContender
+import me.ahoo.simba.core.MutexState
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Unit test for the stop/in-flight-task race. No database required:
+ * [MutexOwnerRepository] is faked with a blocking implementation that mimics a
+ * JDBC call (interrupt-insensitive).
+ *
+ * stopContend shuts the executor down without awaiting the in-flight task; a JDBC
+ * call cannot be interrupted, so the task keeps running and its trailing
+ * nextSchedule call throws RejectedExecutionException on the shut-down executor —
+ * on the failure path even from inside the catch block. The thrown REE is
+ * unobservable through the (cancelled) scheduled future, so the test swaps in a
+ * recording executor subclass and asserts no scheduling is ATTEMPTED after stop.
+ */
+class JdbcMutexContendServiceStopTest {
+    @Test
+    fun `contend task completing after stop must not attempt to reschedule`() {
+        val invoked = CountDownLatch(1)
+        val inFlight = CountDownLatch(1)
+        val acquireCount = AtomicInteger()
+        val repository = object : MutexOwnerRepository {
+            override fun initMutex(mutex: String) = true
+            override fun tryInitMutex(mutex: String) = true
+
+            override fun getOwner(mutex: String): MutexOwnerEntity {
+                throw NotFoundMutexOwnerException("not expected in this test")
+            }
+
+            override fun acquire(mutex: String, contenderId: String, ttl: Long, transition: Long) = false
+
+            override fun acquireAndGetOwner(
+                mutex: String,
+                contenderId: String,
+                ttl: Long,
+                transition: Long
+            ): MutexOwnerEntity {
+                acquireCount.incrementAndGet()
+                invoked.countDown()
+                // interrupt-insensitive wait, like a JDBC call in flight
+                while (inFlight.count > 0) {
+                    try {
+                        inFlight.await()
+                    } catch (_: InterruptedException) {
+                    }
+                }
+                return MutexOwnerEntity(mutex, contenderId, 0, Long.MAX_VALUE, Long.MAX_VALUE)
+            }
+
+            override fun release(mutex: String, contenderId: String) = true
+
+            override fun ensureOwner(mutex: String): MutexOwnerEntity {
+                throw NotFoundMutexOwnerException("not expected in this test")
+            }
+        }
+        val contender = object : AbstractMutexContender("m") {
+            override fun onAcquired(mutexState: MutexState) = Unit
+            override fun onReleased(mutexState: MutexState) = Unit
+        }
+        val contendService = JdbcMutexContendService(
+            contender,
+            Executor { it.run() }, // synchronous handleExecutor: notifyOwner applies inline
+            repository,
+            Duration.ofMillis(300), // window to swap in the recording executor before the task fires
+            Duration.ofSeconds(10),
+            Duration.ofSeconds(6)
+        )
+
+        contendService.start()
+
+        val recordingExecutor = RecordingScheduledExecutor()
+        val executorField = JdbcMutexContendService::class.java.getDeclaredField("executorService")
+        executorField.isAccessible = true
+        executorField.set(contendService, recordingExecutor)
+
+        assertThat("contend task should reach the repository", invoked.await(5, TimeUnit.SECONDS))
+
+        contendService.stop()
+        // stop shut the recording executor down; the in-flight task is still blocked
+        assertThat(recordingExecutor.scheduleAttemptsWhenShutdown.get(), equalTo(0))
+
+        inFlight.countDown()
+
+        // the in-flight task finishes now: any (buggy) rescheduling attempt lands on the
+        // shut-down recording executor within milliseconds
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
+        while (recordingExecutor.scheduleAttemptsWhenShutdown.get() == 0 &&
+            System.nanoTime() < deadline
+        ) {
+            Thread.sleep(20)
+        }
+        assertThat(
+            "nextSchedule must not attempt to schedule on the shut-down executor after stop",
+            recordingExecutor.scheduleAttemptsWhenShutdown.get(),
+            equalTo(0)
+        )
+        assertThat("no further contention should run after stop", acquireCount.get(), equalTo(1))
+    }
+
+    private class RecordingScheduledExecutor : ScheduledThreadPoolExecutor(1) {
+        val scheduleAttemptsWhenShutdown = AtomicInteger()
+
+        override fun schedule(command: Runnable, delay: Long, unit: TimeUnit): ScheduledFuture<*>? {
+            if (isShutdown) {
+                scheduleAttemptsWhenShutdown.incrementAndGet()
+            }
+            return super.schedule(command, delay, unit)
+        }
+    }
+}

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryExceptionTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryExceptionTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.jdbc
+
+import me.ahoo.simba.SimbaException
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.SQLException
+import javax.sql.DataSource
+
+/**
+ * Unit tests for the exception-wrapping contract of acquireAndGetOwner.
+ * No database required: JDBC interfaces are faked with JDK proxies, and the
+ * thrown failures deliberately carry a null message (e.g. JVM NullPointerException,
+ * StackOverflowError) — message!! would replace the intended SimbaException with a
+ * KotlinNullPointerException and lose the cause chain.
+ */
+class JdbcMutexOwnerRepositoryExceptionTest {
+    @Test
+    fun `acquireAndGetOwner wraps null-message statement failure as SimbaException keeping the cause`() {
+        // null message by construction; a RuntimeException passes the JDK proxy's
+        // declared-exception check (undeclared checked exceptions get wrapped in
+        // UndeclaredThrowableException before reaching the repository)
+        val boom = IllegalStateException()
+        val repository = JdbcMutexOwnerRepository(dataSourceFailingStatementsWith(boom))
+
+        val error = assertThrows<SimbaException> {
+            repository.acquireAndGetOwner("m", "c1", 10_000, 6_000)
+        }
+
+        assertThat(error.cause, sameInstance(boom))
+    }
+
+    @Test
+    fun `acquireAndGetOwner wraps null-message connection failure as SimbaException keeping the cause`() {
+        val boom = SQLException() // message is null by construction
+        val repository = JdbcMutexOwnerRepository(
+            proxy(DataSource::class.java) { method, _ ->
+                if (method.name == "getConnection") throw boom
+                null
+            }
+        )
+
+        val error = assertThrows<SimbaException> {
+            repository.acquireAndGetOwner("m", "c1", 10_000, 6_000)
+        }
+
+        assertThat(error.cause, sameInstance(boom))
+    }
+
+    private fun dataSourceFailingStatementsWith(boom: Throwable): DataSource {
+        val statement = proxy(PreparedStatement::class.java) { method, _ ->
+            if (method.name == "executeUpdate") throw boom
+            null
+        }
+        val connection = proxy(Connection::class.java) { method, _ ->
+            if (method.name == "prepareStatement") statement else null
+        }
+        return proxy(DataSource::class.java) { method, _ ->
+            if (method.name == "getConnection") connection else null
+        }
+    }
+
+    private fun <T : Any> proxy(iface: Class<T>, handler: (Method, Array<Any?>?) -> Any?): T {
+        return Proxy.newProxyInstance(
+            iface.classLoader,
+            arrayOf(iface),
+            InvocationHandler { _, method, args -> handler(method, args) }
+        ) as T
+    }
+}


### PR DESCRIPTION
## Summary

Two JDBC exception-path fixes from the same code review as #440 (no file overlap with it). Both were developed test-first with RED verified on the unfixed code; the unit tests need **no MySQL** (JDBC interfaces are faked with JDK proxies / a hand-written repository).

### 1. `acquireAndGetOwner` — `message!!` destroyed the intended exception

Both wrap sites used `SimbaException(throwable.message!!, throwable)`. Any null-message failure — JVM `NullPointerException`, `StackOverflowError`, driver-level `SQLException` — blew up into a `KotlinNullPointerException` instead, replacing the intended `SimbaException` and losing the cause chain exactly where debugging needs it most. Both sites now use the cause-only `SimbaException(cause)` constructor.

- Regression tests: JDK proxies fake `DataSource`/`Connection`/`PreparedStatement` and throw deliberately null-message failures at both sites; assert `SimbaException` keeps the original cause instance. RED pre-fix: NPE raised **at `JdbcMutexOwnerRepository.kt:212/:216`** (verified in stack traces), GREEN post-fix.

### 2. `nextSchedule` on a shut-down executor after `stop()`

`stopContend` cancels and shuts the executor down without awaiting the in-flight contend task — JDBC calls are not interruptible, so the task keeps running. When it finished, its trailing `nextSchedule` call hit the shut-down executor; the `RejectedExecutionException` was unobservable (swallowed into the cancelled scheduled future), and on the failure path it was thrown from inside the catch block, replacing the logged retry. `nextSchedule` now returns early when `status` is not active — the same guard the Redis backend already has.

- Regression test: a blocking fake repository mimics the in-flight JDBC call across `stop()`; a recording `ScheduledThreadPoolExecutor` subclass is swapped in and counts scheduling attempts on the shut-down executor. RED pre-fix: **2 attempts** (the throw plus the retry from the catch block — matching the code path), GREEN post-fix: 0.

## Process note

Two early test drafts were false REDs (one failed inside the test's own proxy due to null `args` on no-arg methods; one observed only the future's `CancellationException`). Both were caught because the "fixed" code did not turn them green, corrected, and re-verified RED against the unfixed code before the fixes were re-applied.

## Test plan

- [x] `simba-jdbc:test` — new unit tests (no MySQL needed) GREEN
- [x] `simba-jdbc:detekt`, `git diff --check`
- [x] `simba-spring-boot-starter:test` (no side effects)
- [ ] full `simba-jdbc:check` integration suite — needs MySQL; covered by CI