### PR TITLE
fix: pooled-connection autoCommit restore, scheduling visibility, test coverage

### DIFF
--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt
@@ -185,31 +185,40 @@ class JdbcMutexOwnerRepository(private val dataSource: DataSource) : MutexOwnerR
     override fun acquireAndGetOwner(mutex: String, contenderId: String, ttl: Long, transition: Long): MutexOwnerEntity {
         try {
             dataSource.connection.use { connection ->
+                val previousAutoCommit = connection.autoCommit
                 connection.autoCommit = false
-                return try {
-                    var acquired = acquire(connection, mutex, contenderId, ttl, transition)
-                    var mutexOwner = ensureOwner(connection, mutex)
-                    if (!acquired && !mutexOwner.hasOwner()) {
-                        /**
-                         * 没有竞争到领导权 && 当前不存在领导者 ==> 初始化时
-                         */
-                        log.info {
-                            "acquireAndGetOwner - There is no competition for leadership && There is currently no leader [When initializing]. Retry!"
+                try {
+                    return try {
+                        var acquired = acquire(connection, mutex, contenderId, ttl, transition)
+                        var mutexOwner = ensureOwner(connection, mutex)
+                        if (!acquired && !mutexOwner.hasOwner()) {
+                            /**
+                             * 没有竞争到领导权 && 当前不存在领导者 ==> 初始化时
+                             */
+                            log.info {
+                                "acquireAndGetOwner - There is no competition for leadership && There is currently no leader [When initializing]. Retry!"
+                            }
+                            acquired = acquire(connection, mutex, contenderId, ttl, transition)
+                            mutexOwner = ensureOwner(connection, mutex)
                         }
-                        acquired = acquire(connection, mutex, contenderId, ttl, transition)
-                        mutexOwner = ensureOwner(connection, mutex)
+                        check(!(acquired && !mutexOwner.isOwner(contenderId))) {
+                            /**
+                             * 当前竞争者已竞争到领导权 && 最新 mutexOwner 不是当前竞争者
+                             */
+                            "Contender:[$contenderId] has acquired leadership, but MutexOwner status is inconsistent!"
+                        }
+                        connection.commit()
+                        mutexOwner
+                    } catch (throwable: Throwable) {
+                        connection.rollback()
+                        throw SimbaException(throwable)
                     }
-                    check(!(acquired && !mutexOwner.isOwner(contenderId))) {
-                        /**
-                         * 当前竞争者已竞争到领导权 && 最新 mutexOwner 不是当前竞争者
-                         */
-                        "Contender:[$contenderId] has acquired leadership, but MutexOwner status is inconsistent!"
-                    }
-                    connection.commit()
-                    mutexOwner
-                } catch (throwable: Throwable) {
-                    connection.rollback()
-                    throw SimbaException(throwable)
+                } finally {
+                    /*
+                     * Pools that do not reset autoCommit on return would silently roll back
+                     * every later autoCommit-mode statement on the recycled connection.
+                     */
+                    connection.autoCommit = previousAutoCommit
                 }
             }
         } catch (sqlException: SQLException) {

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryAutoCommitTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryAutoCommitTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.jdbc
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.sql.DataSource
+
+/**
+ * Unit test for pooled-connection state restore. No database required.
+ *
+ * acquireAndGetOwner flips autoCommit off for its transaction; returning the
+ * connection to the pool without restoring the previous value relies on the pool
+ * to reset it — a DataSource that does not would silently roll back every later
+ * autoCommit-mode statement on the recycled connection.
+ */
+class JdbcMutexOwnerRepositoryAutoCommitTest {
+    @Test
+    fun `acquireAndGetOwner restores the previous autoCommit before releasing the connection`() {
+        val autoCommit = AtomicBoolean(true)
+        val now = System.currentTimeMillis()
+        val repository = JdbcMutexOwnerRepository(
+            proxy(DataSource::class.java) { method, _ ->
+                if (method.name == "getConnection") recordingConnection(autoCommit, now) else null
+            }
+        )
+
+        val owner = repository.acquireAndGetOwner("m", "c1", 10_000, 6_000)
+
+        // sanity: the call completed through the "not acquired, someone else owns it" path
+        assertThat(owner.ownerId, equalTo("other-owner"))
+        assertThat(
+            "autoCommit must be restored before the connection goes back to the pool",
+            autoCommit.get(),
+            equalTo(true)
+        )
+    }
+
+    private fun recordingConnection(autoCommit: AtomicBoolean, now: Long): Connection {
+        val statement = recordingStatement(now)
+        return proxy(Connection::class.java) { method, args ->
+            when (method.name) {
+                "getAutoCommit" -> autoCommit.get()
+                "setAutoCommit" -> {
+                    autoCommit.set(args?.get(0) as Boolean)
+                    null
+                }
+
+                "prepareStatement" -> statement
+                else -> null
+            }
+        }
+    }
+
+    private fun recordingStatement(now: Long): PreparedStatement {
+        val resultSet = ownerResultSet(now)
+        return proxy(PreparedStatement::class.java) { method, _ ->
+            when (method.name) {
+                "executeUpdate" -> 0 // not acquired
+                "executeQuery" -> resultSet
+                else -> null
+            }
+        }
+    }
+
+    private fun ownerResultSet(now: Long): ResultSet {
+        // getLong is called with distinct column indexes, so the handler keys on the args
+        return proxy(ResultSet::class.java) { method, args ->
+            when (method.name) {
+                "next" -> true
+                "getLong" -> when (args?.get(0)) {
+                    2 -> now + 10_000 // ttlAt: owner still in ttl
+                    3 -> now + 16_000 // transitionAt: owner still in transition
+                    else -> now // acquiredAt / currentAt
+                }
+
+                "getString" -> "other-owner"
+                "getInt" -> 1
+                else -> null
+            }
+        }
+    }
+
+    private fun <T : Any> proxy(iface: Class<T>, handler: (Method, Array<Any?>?) -> Any?): T {
+        return Proxy.newProxyInstance(
+            iface.classLoader,
+            arrayOf(iface),
+            InvocationHandler { _, method, args -> handler(method, args) }
+        ) as T
+    }
+}

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryExceptionTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryExceptionTest.kt
@@ -71,7 +71,11 @@ class JdbcMutexOwnerRepositoryExceptionTest {
             null
         }
         val connection = proxy(Connection::class.java) { method, _ ->
-            if (method.name == "prepareStatement") statement else null
+            when (method.name) {
+                "prepareStatement" -> statement
+                "getAutoCommit" -> true
+                else -> null
+            }
         }
         return proxy(DataSource::class.java) { method, _ ->
             if (method.name == "getConnection") connection else null

--- a/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/JdbcPropertiesTest.kt
+++ b/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/JdbcPropertiesTest.kt
@@ -12,7 +12,6 @@
  */
 package me.ahoo.simba.spring.boot.starter.jdbc
 
-import me.ahoo.simba.spring.boot.starter.redis.RedisProperties
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
@@ -36,7 +35,7 @@ internal class JdbcPropertiesTest {
 
     @Test
     fun setEnabled() {
-        val properties = RedisProperties(false)
+        val properties = JdbcProperties(enabled = false)
         assertThat(properties.enabled, equalTo(false))
     }
 

--- a/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
+++ b/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
@@ -78,6 +78,12 @@ class SpringRedisMutexContendService(
     private val listenTopics: List<ChannelTopic> = listOf(ChannelTopic(mutexChannel), ChannelTopic(contenderChannel))
     private val contendPeriod: ContendPeriod = ContendPeriod(contenderId)
     private val mutexMessageListener: MutexMessageListener = MutexMessageListener()
+
+    /**
+     * Written by the scheduling executor thread and cancelled by the stopping thread;
+     * without volatile visibility the stopper can miss the latest reference and fail to cancel.
+     */
+    @Volatile
     private var scheduleFuture: ScheduledFuture<MutexOwner>? = null
 
     /**


### PR DESCRIPTION
## Summary

Third batch of code-review fixes — low-cost robustness items. **Stacked on #441** (shares `acquireAndGetOwner` edits; it will retarget to `main` automatically once #441 merges). No file overlap with #440.

### 1. `fix(jdbc)`: restore connection `autoCommit` after transactional acquire

`acquireAndGetOwner` flipped `autoCommit` off but never restored it, relying on the pool to reset state on return. A `DataSource` whose pool does not reset it would silently roll back every later autoCommit-mode statement executed on the recycled connection. The previous value is now saved and restored in a `finally` block covering both commit and rollback paths.

- Regression test (no MySQL needed): a recording proxy connection drives the "not acquired, someone else owns it" path and asserts `autoCommit` is back to its original value before the connection is released. RED pre-fix / GREEN post-fix.

### 2. `fix(redis)`: `scheduleFuture` visibility

`scheduleFuture` is written by the scheduling executor thread and cancelled by the thread calling `stop()`; without a happens-before edge the stopper can observe a stale `null` and fail to cancel the pending contention task. Now `@Volatile`, mirroring the JDBC counterpart (`contendScheduledFuture`). Visibility-only change; not unit-testable deterministically — justified by inspection and backend consistency.

### 3. `test(starter)`: `JdbcPropertiesTest.setEnabled` copy-paste

The case instantiated `RedisProperties(false)` through a copy-pasted import, so `JdbcProperties`' `enabled=false` constructor path was never covered.

## Test plan

- [x] `simba-jdbc:test` unit tests incl. new autoCommit regression — GREEN
- [x] `simba-spring-redis:test` (local Redis), `simba-spring-boot-starter:test`
- [x] `detekt` on jdbc/redis/starter, `git diff --check`
- [ ] full `simba-jdbc:check` integration suite — needs MySQL; covered by CI