### PR TITLE
fix: drop post-stop owner notifications and unmask ensureOwner init failures

### DIFF
--- a/simba-core/src/main/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalService.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalService.kt
@@ -74,7 +74,19 @@ abstract class AbstractMutexRetrievalService protected constructor(
 
     protected abstract fun startRetrieval()
     protected abstract fun stopRetrieval()
+
     protected fun notifyOwner(newOwner: MutexOwner): CompletableFuture<Void> {
+        /*
+         * Notifications submitted at INITIAL (e.g. an in-flight contend task or a late
+         * backend callback finishing after stop) must not revive ownership. STOPPING is
+         * deliberately allowed: every backend submits its release notification while stopping.
+         */
+        if (Status.INITIAL == status) {
+            log.warn {
+                "notifyOwner - ignore - mutex:[${retriever.mutex}] - newOwner:[$newOwner] is not active[$status]."
+            }
+            return CompletableFuture.completedFuture(null)
+        }
         return CompletableFuture.runAsync({ safeNotifyOwner(newOwner) }, handleExecutor)
     }
 

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
@@ -158,6 +158,8 @@ class AbstractMutexRetrievalServiceTest {
             val contender = ConcurrentCountingContender("m", "c1-$attempt")
             val service = FakeMutexContendService(contender, BarrierPairExecutor())
             val selfOwner = MutexOwner(contender.contenderId, 0, Long.MAX_VALUE, Long.MAX_VALUE)
+            // notifications are only meaningful while the service is active
+            service.start()
 
             val first = service.publishOwner(selfOwner)
             val second = service.publishOwner(selfOwner)
@@ -169,6 +171,23 @@ class AbstractMutexRetrievalServiceTest {
                 contender.acquiredCount.get(),
                 equalTo(1)
             )
+            service.stop()
         }
+    }
+
+    @Test
+    fun `publishOwner after stop must be ignored`() {
+        val contender = FakeMutexContender("m", "c1")
+        val service = FakeMutexContendService(contender)
+        service.start()
+        service.stop()
+        assertThat(service.status, equalTo(MutexRetrievalService.Status.INITIAL))
+
+        // a late source (in-flight contend task, late callback) submitting after stop
+        // must not revive ownership or fire contender callbacks
+        service.publishOwner(MutexOwner("c1", 0, 100, 200)).join()
+
+        assertThat(service.mutexState, equalTo(MutexState.NONE))
+        assertThat(contender.acquired.size, equalTo(0))
     }
 }

--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt
@@ -141,7 +141,12 @@ class JdbcMutexOwnerRepository(private val dataSource: DataSource) : MutexOwnerR
                     "ensureOwner - initMutex:[$mutex]."
                 }
                 initMutex(connection, mutex)
-            } catch (sqlIntegrityConstraintViolationException: SQLException) {
+            } catch (sqlIntegrityConstraintViolationException: SQLIntegrityConstraintViolationException) {
+                /*
+                 * Only the unique-key race of concurrent initialization is tolerable;
+                 * any other SQLException must propagate instead of being masked
+                 * by the trailing getOwner's own failure.
+                 */
                 log.warn(sqlIntegrityConstraintViolationException) {
                     sqlIntegrityConstraintViolationException.message
                 }

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryAutoCommitTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryAutoCommitTest.kt
@@ -15,9 +15,6 @@ package me.ahoo.simba.jdbc
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
-import java.lang.reflect.InvocationHandler
-import java.lang.reflect.Method
-import java.lang.reflect.Proxy
 import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.ResultSet
@@ -38,7 +35,7 @@ class JdbcMutexOwnerRepositoryAutoCommitTest {
         val autoCommit = AtomicBoolean(true)
         val now = System.currentTimeMillis()
         val repository = JdbcMutexOwnerRepository(
-            proxy(DataSource::class.java) { method, _ ->
+            jdbcProxy(DataSource::class.java) { method, _ ->
                 if (method.name == "getConnection") recordingConnection(autoCommit, now) else null
             }
         )
@@ -56,7 +53,7 @@ class JdbcMutexOwnerRepositoryAutoCommitTest {
 
     private fun recordingConnection(autoCommit: AtomicBoolean, now: Long): Connection {
         val statement = recordingStatement(now)
-        return proxy(Connection::class.java) { method, args ->
+        return jdbcProxy(Connection::class.java) { method, args ->
             when (method.name) {
                 "getAutoCommit" -> autoCommit.get()
                 "setAutoCommit" -> {
@@ -72,7 +69,7 @@ class JdbcMutexOwnerRepositoryAutoCommitTest {
 
     private fun recordingStatement(now: Long): PreparedStatement {
         val resultSet = ownerResultSet(now)
-        return proxy(PreparedStatement::class.java) { method, _ ->
+        return jdbcProxy(PreparedStatement::class.java) { method, _ ->
             when (method.name) {
                 "executeUpdate" -> 0 // not acquired
                 "executeQuery" -> resultSet
@@ -83,7 +80,7 @@ class JdbcMutexOwnerRepositoryAutoCommitTest {
 
     private fun ownerResultSet(now: Long): ResultSet {
         // getLong is called with distinct column indexes, so the handler keys on the args
-        return proxy(ResultSet::class.java) { method, args ->
+        return jdbcProxy(ResultSet::class.java) { method, args ->
             when (method.name) {
                 "next" -> true
                 "getLong" -> when (args?.get(0)) {
@@ -97,13 +94,5 @@ class JdbcMutexOwnerRepositoryAutoCommitTest {
                 else -> null
             }
         }
-    }
-
-    private fun <T : Any> proxy(iface: Class<T>, handler: (Method, Array<Any?>?) -> Any?): T {
-        return Proxy.newProxyInstance(
-            iface.classLoader,
-            arrayOf(iface),
-            InvocationHandler { _, method, args -> handler(method, args) }
-        ) as T
     }
 }

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryEnsureOwnerTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryEnsureOwnerTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.jdbc
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.util.concurrent.atomic.AtomicInteger
+import javax.sql.DataSource
+
+/**
+ * Unit test for ensureOwner's concurrent-init catch scope. No database required.
+ *
+ * The catch was declared for the unique-key race on concurrent initialization but
+ * caught every SQLException: an unrelated init failure (connection dropped, syntax,
+ * privileges) was logged as a warn and then MASKED by the subsequent getOwner's own
+ * failure, sending troubleshooting after the wrong root cause.
+ */
+class JdbcMutexOwnerRepositoryEnsureOwnerTest {
+    @Test
+    fun `ensureOwner propagates the init failure instead of masking it with the retry read`() {
+        val initBoom = SQLException("connection broken during init")
+        val readBoom = SQLException("stale read on retry")
+        val repository = JdbcMutexOwnerRepository(
+            jdbcProxy(DataSource::class.java) { method, _ ->
+                if (method.name == "getConnection") statementsBySql(initBoom, readBoom) else null
+            }
+        )
+
+        val error = assertThrows<SQLException> {
+            repository.ensureOwner("m")
+        }
+
+        assertThat(
+            "the ORIGINAL init failure must propagate, not the masking retry read",
+            error.message,
+            containsString("connection broken during init")
+        )
+    }
+
+    private fun statementsBySql(initBoom: SQLException, readBoom: SQLException): Connection {
+        val selectCalls = AtomicInteger()
+        return jdbcProxy(Connection::class.java) { method, args ->
+            if (method.name != "prepareStatement") return@jdbcProxy null
+            when {
+                (args?.get(0) as String).contains("insert", ignoreCase = true) ->
+                    jdbcProxy(PreparedStatement::class.java) { m, _ ->
+                        if (m.name == "executeUpdate") throw initBoom
+                        null
+                    }
+
+                else -> jdbcProxy(PreparedStatement::class.java) { m, _ ->
+                    when (m.name) {
+                        // first read: row missing -> NotFoundMutexOwnerException -> init path;
+                        // retry read after a swallowed init failure: the masking failure
+                        "executeQuery" ->
+                            if (selectCalls.getAndIncrement() == 0) emptyResultSet() else throw readBoom
+
+                        else -> null
+                    }
+                }
+            }
+        }
+    }
+
+    private fun emptyResultSet(): ResultSet {
+        return jdbcProxy(ResultSet::class.java) { m, _ ->
+            if (m.name == "next") false else null
+        }
+    }
+}

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryExceptionTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepositoryExceptionTest.kt
@@ -17,9 +17,6 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.sameInstance
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.lang.reflect.InvocationHandler
-import java.lang.reflect.Method
-import java.lang.reflect.Proxy
 import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.SQLException
@@ -52,7 +49,7 @@ class JdbcMutexOwnerRepositoryExceptionTest {
     fun `acquireAndGetOwner wraps null-message connection failure as SimbaException keeping the cause`() {
         val boom = SQLException() // message is null by construction
         val repository = JdbcMutexOwnerRepository(
-            proxy(DataSource::class.java) { method, _ ->
+            jdbcProxy(DataSource::class.java) { method, _ ->
                 if (method.name == "getConnection") throw boom
                 null
             }
@@ -66,27 +63,19 @@ class JdbcMutexOwnerRepositoryExceptionTest {
     }
 
     private fun dataSourceFailingStatementsWith(boom: Throwable): DataSource {
-        val statement = proxy(PreparedStatement::class.java) { method, _ ->
+        val statement = jdbcProxy(PreparedStatement::class.java) { method, _ ->
             if (method.name == "executeUpdate") throw boom
             null
         }
-        val connection = proxy(Connection::class.java) { method, _ ->
+        val connection = jdbcProxy(Connection::class.java) { method, _ ->
             when (method.name) {
                 "prepareStatement" -> statement
                 "getAutoCommit" -> true
                 else -> null
             }
         }
-        return proxy(DataSource::class.java) { method, _ ->
+        return jdbcProxy(DataSource::class.java) { method, _ ->
             if (method.name == "getConnection") connection else null
         }
-    }
-
-    private fun <T : Any> proxy(iface: Class<T>, handler: (Method, Array<Any?>?) -> Any?): T {
-        return Proxy.newProxyInstance(
-            iface.classLoader,
-            arrayOf(iface),
-            InvocationHandler { _, method, args -> handler(method, args) }
-        ) as T
     }
 }

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcTestProxies.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcTestProxies.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.jdbc
+
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+/**
+ * JDK dynamic proxy helper for faking JDBC interfaces in unit tests (no database needed).
+ *
+ * Note: no-arg methods receive a null args array from the InvocationHandler bridge,
+ * so the handler parameter is nullable.
+ */
+internal fun <T : Any> jdbcProxy(iface: Class<T>, handler: (Method, Array<Any?>?) -> Any?): T {
+    return Proxy.newProxyInstance(
+        iface.classLoader,
+        arrayOf(iface),
+        InvocationHandler { _, method, args -> handler(method, args) }
+    ) as T
+}


### PR DESCRIPTION
## Summary

Fourth batch of code-review follow-ups. Both changes test-first (RED verified on unfixed code).

### 1. `fix(core)`: ignore owner notifications submitted after `stop()`

A late source finishing after `stop()` — an in-flight contend task or a late backend callback — could still submit an owner notification that revived `mutexState` and fired contender callbacks on a stopped service. #440 guarded the zookeeper entry point; this closes the same window at the core choke point for **all** backends (jdbc in-flight contend task, redis scheduled-path submission).

- `notifyOwner` now drops submissions made at `INITIAL` status. **`STOPPING` stays allowed** — every backend submits its release notification while stopping (`CloseMode.NOTIFY_LEADER`, redis `release()`, jdbc `stopContend`), which the TCK `releasedFuture` assertions depend on; all backend suites stay green.
- Regression test: after `start(); stop()`, a late `publishOwner(self)` leaves `mutexState` at NONE and fires no contender callbacks (deterministic RED pre-fix).
- The concurrent-notification stress test now starts its services so notifications come from an active state, as production does.

### 2. `fix(jdbc)`: unmask `ensureOwner` init failures

The catch around `initMutex` was written for the unique-key race of concurrent initialization but caught **every** `SQLException`: an unrelated init failure (connection dropped, syntax, privileges) was logged as a warn and then masked by the trailing `getOwner`'s own failure — troubleshooting chased the wrong root cause. Only `SQLIntegrityConstraintViolationException` is tolerated now.

- Regression test (no MySQL): the first read reports the row missing, `initMutex` fails with a plain `SQLException`, and the **original** failure must propagate — pre-fix the masking retry read's exception escaped instead.
- The per-file JDK proxy helpers are consolidated into a shared `JdbcTestProxies.kt`.

### Not fixed on purpose

- `mutex_acquire.lua` expired-key concat (#14): a 15s stress probe (1ms-TTL key recreated continuously + hammered `EVAL acquire`) on Redis 8.10 produced **zero** Lua errors — the mid-script expiry window appears closed by modern Redis semantics. Left as suspected/unreproduced; a symmetric `guard.lua`-style fallback can be added as defensive hardening if desired.

## Test plan

- [x] `simba-core:check`, `simba-zookeeper:check`, `simba-spring-redis:check` (local Redis) — green
- [x] `simba-jdbc` unit tests (no MySQL) + `detekt` — green
- [ ] CI: full matrix incl. MySQL-backed `simba-jdbc` checks