### PR TITLE
docs(wiki): correct jdbc concurrency wording and document MySQL version floor

### DIFF
--- a/wiki/architecture/backends.md
+++ b/wiki/architecture/backends.md
@@ -12,8 +12,8 @@ dependencies, and operational complexity.
 
 ## JDBC Backend
 
-The JDBC backend uses a MySQL table (`simba_mutex`) with optimistic locking via a `version`
-column. Contention is driven by polling through a `ScheduledThreadPoolExecutor`.
+The JDBC backend uses a MySQL table (`simba_mutex`) with atomic conditional `UPDATE`s guarded by
+owner/transition predicates. Contention is driven by polling through a `ScheduledThreadPoolExecutor`.
 
 ### Schema
 
@@ -40,16 +40,16 @@ erDiagram
         bigint ttl_at "Epoch millis: TTL expiry"
         bigint transition_at "Epoch millis: transition window end"
         char owner_id "Contender ID of current owner"
-        int version "Optimistic lock version counter"
+        int version "State change counter"
     }
 ```
 
 The `MutexOwnerEntity` class ([`JdbcMutexOwnerRepository.kt`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/MutexOwnerRepository.kt))
-extends `MutexOwner` with a `version` field for optimistic locking and a `currentDbAt`
+extends `MutexOwner` with a `version` state-change counter and a `currentDbAt`
 field that captures the database server's current timestamp, preventing clock skew issues
 between application nodes.
 
-### Atomic Acquire (Optimistic Locking)
+### Atomic Acquire (Conditional Update)
 
 The `SQL_ACQUIRE` query in
 [`JdbcMutexOwnerRepository`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt#L43)
@@ -421,7 +421,7 @@ flowchart LR
 
 | Feature | JDBC | Redis | Zookeeper |
 |---|---|---|---|
-| **Acquisition mechanism** | `UPDATE ... WHERE` with optimistic locking | `SET NX PX` atomic Lua script | Curator `LeaderLatch` (ephemeral sequential nodes) |
+| **Acquisition mechanism** | `UPDATE ... WHERE` guarded by owner/transition predicates | `SET NX PX` atomic Lua script | Curator `LeaderLatch` (ephemeral sequential nodes) |
 | **Notification** | Polling via `ScheduledThreadPoolExecutor` | Pub/Sub instant notification | ZNode watches (built into Curator) |
 | **Failure detection** | TTL expiry (polling interval) | Key TTL expiry + Pub/Sub | Ephemeral node deletion on session loss |
 | **Latency** | Polling interval (typically ttl-based) | Sub-millisecond (Pub/Sub push) | Session timeout (typically 5-30s) |

--- a/wiki/architecture/index.md
+++ b/wiki/architecture/index.md
@@ -278,7 +278,7 @@ flowchart LR
 | Module | Role |
 |---|---|
 | `simba-core` | Core interfaces and abstract implementations |
-| `simba-jdbc` | JDBC/MySQL backend — polling with optimistic locking |
+| `simba-jdbc` | JDBC/MySQL backend — polling with atomic conditional updates |
 | `simba-spring-redis` | Redis backend — Lua scripts + pub/sub notifications |
 | `simba-zookeeper` | Zookeeper backend — Curator LeaderLatch recipe |
 | `simba-spring-boot-starter` | Spring Boot auto-configuration |

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -19,7 +19,7 @@ hero:
 features:
   - icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
     title: Multiple Backends
-    details: "Choose the storage that fits your stack: JDBC/MySQL with optimistic locking, Redis with atomic Lua scripts and pub/sub, or Zookeeper via Apache Curator."
+    details: "Choose the storage that fits your stack: JDBC/MySQL with atomic conditional updates, Redis with atomic Lua scripts and pub/sub, or Zookeeper via Apache Curator."
   - icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
     title: Leader Election
     details: "Automatic ownership with configurable TTL and transition periods. The current leader renews before expiry; contenders wait with jitter to avoid thundering herd."

--- a/wiki/modules/index.md
+++ b/wiki/modules/index.md
@@ -71,7 +71,7 @@ graph TB
 | Module | Role | Key Types | Dependencies |
 |---|---|---|---|
 | **simba-core** | Core interfaces, abstract classes, value objects | `MutexContender`, `MutexContendService`, `SimbaLocker`, `AbstractScheduler` | kotlin-logging, cosid-core, guava |
-| **simba-jdbc** | JDBC/MySQL backend with optimistic locking | `JdbcMutexContendService`, `JdbcMutexOwnerRepository` | simba-core, JDBC driver |
+| **simba-jdbc** | JDBC/MySQL backend with atomic conditional updates | `JdbcMutexContendService`, `JdbcMutexOwnerRepository` | simba-core, JDBC driver |
 | **simba-spring-redis** | Redis backend with Lua scripts and pub/sub | `SpringRedisMutexContendService`, Lua scripts | simba-core, spring-data-redis |
 | **simba-zookeeper** | Zookeeper backend using Curator LeaderLatch | `ZookeeperMutexContendService` | simba-core, curator-recipes |
 | **simba-spring-boot-starter** | Auto-configuration for all backends | `SimbaJdbcAutoConfiguration`, `SimbaSpringRedisAutoConfiguration`, `SimbaZookeeperAutoConfiguration` | simba-core + conditional backend deps |
@@ -89,7 +89,7 @@ graph LR
 
         J_REPO["MutexOwnerRepository"]
         J_SCHED["ScheduledThreadPoolExecutor<br>(polling)"]
-        J_DDL["simba_mutex table<br>optimistic locking"]
+        J_DDL["simba_mutex table<br>conditional UPDATE"]
     end
     subgraph sg_30 ["Redis Backend"]
 
@@ -117,7 +117,7 @@ graph LR
 |---|---|---|---|
 | **Coordination mechanism** | Poll with `ScheduledThreadPoolExecutor` | Lua scripts + pub/sub | Curator `LeaderLatch` |
 | **Lock storage** | `simba_mutex` table | Redis key (`simba:{mutex}`) | ZNode (`/simba/{mutex}`) |
-| **Ownership transfer** | Optimistic locking via `version` column | Sorted set wait queue + pub/sub notification | ZK watcher on latch participants |
+| **Ownership transfer** | Atomic conditional `UPDATE` guarded by owner/transition predicates | Sorted set wait queue + pub/sub notification | ZK watcher on latch participants |
 | **Time source** | MySQL `current_timestamp(3)` | System clock (client-side) | ZK server time |
 | **External dependency** | MySQL instance | Redis instance | ZooKeeper ensemble |
 | **Best for** | Existing relational DB infrastructure | High-throughput, low-latency | Strong consistency guarantees |

--- a/wiki/modules/simba-jdbc.md
+++ b/wiki/modules/simba-jdbc.md
@@ -1,11 +1,13 @@
 ---
 title: simba-jdbc Module
-description: JDBC/MySQL backend for Simba distributed mutex -- schema DDL, optimistic locking, polling-based contention, and auto-configuration properties.
+description: JDBC/MySQL backend for Simba distributed mutex -- schema DDL, atomic conditional updates, polling-based contention, and auto-configuration properties.
 ---
 
 # simba-jdbc Module
 
-The `simba-jdbc` module provides a JDBC-based distributed mutex backend using MySQL. It uses optimistic locking (a `version` column) to ensure safe concurrent updates to the `simba_mutex` table, and polls the database on a `ScheduledThreadPoolExecutor` to detect ownership changes.
+The `simba-jdbc` module provides a JDBC-based distributed mutex backend using MySQL. It serializes concurrent updates to the `simba_mutex` table with atomic conditional `UPDATE`s guarded by owner/transition predicates, and polls the database on a `ScheduledThreadPoolExecutor` to detect ownership changes.
+
+> **MySQL version requirement**: the backend reads database time through `UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3))`. On 64-bit MySQL 8.0.28+ the returned value is valid through year 3001; on older versions the valid range ends at 2038-01-19 UTC, where out-of-range calls return 0 and owner timestamps silently fall back to JVM time. Plan an upgrade before 2038 if you run an older MySQL.
 
 ## Schema DDL
 
@@ -35,10 +37,10 @@ erDiagram
         bigint ttl_at "epoch millis -- TTL expiry"
         bigint transition_at "epoch millis -- grace period end"
         char owner_id "contender ID of current owner"
-        int version "optimistic lock version"
+        int version "state change counter"
     }
 
-    note for SIMBA_MUTEX "Each row represents one distributed mutex.<br>Optimistic locking via version column prevents<br>concurrent ownership conflicts."
+    note for SIMBA_MUTEX "Each row represents one distributed mutex.<br>Conditional UPDATE + InnoDB row lock prevents<br>concurrent ownership conflicts."
 ```
 
 ### Column Semantics
@@ -50,7 +52,7 @@ erDiagram
 | `ttl_at` | `BIGINT UNSIGNED` | Epoch millis when the TTL expires. After this, other contenders may attempt acquisition. |
 | `transition_at` | `BIGINT UNSIGNED` | Epoch millis when the grace period ends. Equals `acquired_at + ttl + transition`. |
 | `owner_id` | `VARCHAR(128)` | The `contenderId` of the current owner. Empty string when no owner. |
-| `version` | `INT UNSIGNED` | Incremented on every acquire/release for optimistic concurrency control. |
+| `version` | `INT UNSIGNED` | Incremented on every acquire/release as a state-change counter. Not compared in `WHERE` — concurrency is guarded by the owner/transition predicates. |
 
 ## Key Classes
 
@@ -129,7 +131,7 @@ class MutexOwnerEntity(
 
 | Field | Description |
 |---|---|
-| `version` | The optimistic lock version from the database. Used for concurrency control. |
+| `version` | State-change counter from the database. Not used for concurrency decisions. |
 | `currentDbAt` | The database server's current timestamp, used to prevent clock skew issues between application servers. |
 
 ### JdbcMutexContendService
@@ -232,7 +234,7 @@ simba:
 | Situation | Behavior |
 |---|---|
 | Mutex row does not exist | `NotFoundMutexOwnerException` thrown; use `tryInitMutex()` or `ensureOwner()` to auto-create |
-| Concurrent acquisition conflict | Optimistic locking via `version` column; the `UPDATE` returns 0 affected rows |
+| Concurrent acquisition conflict | Atomic conditional `UPDATE` guarded by owner/transition predicates; the loser's `UPDATE` affects 0 rows |
 | SQL error during contend | Logged at ERROR level; next contend scheduled after `ttl` period |
 | Transaction rollback | `acquireAndGetOwner` rolls back on any exception and wraps in `SimbaException` |
 

--- a/wiki/testing/integration-testing.md
+++ b/wiki/testing/integration-testing.md
@@ -66,7 +66,7 @@ CREATE TABLE IF NOT EXISTS simba_mutex (
 );
 ```
 
-The `version` column enables optimistic locking for concurrent acquisition attempts. [`JdbcMutexOwnerRepository`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt) uses `UPDATE ... WHERE version = ?` to ensure only one contender succeeds per cycle.
+Concurrent acquisition attempts are serialized by an atomic conditional `UPDATE` guarded by owner/transition predicates. [`JdbcMutexOwnerRepository`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt) performs `UPDATE ... WHERE mutex = ? AND (transition_at < now OR (owner_id = ? AND transition_at > now))`; the InnoDB row lock plus predicate re-evaluation ensure only one contender succeeds per cycle. The `version` column is a change counter — incremented on every state change, never compared.
 
 ### Test Class
 
@@ -114,7 +114,7 @@ autonumber
     C->>CS: start()
     CS->>CS: startContend() -> schedule(initialDelay)
     CS->>DB: acquireAndGetOwner(mutex, contenderId, ttl, transition)
-    DB->>DB: UPDATE WHERE version matches (optimistic lock)
+    DB->>DB: UPDATE guarded by owner/transition predicates
     DB-->>CS: MutexOwner (current state)
     CS->>CS: notifyOwner(mutexOwner)
     CS->>CS: nextDelay = contendPeriod.ensureNextDelay()

--- a/wiki/zh/architecture/backends.md
+++ b/wiki/zh/architecture/backends.md
@@ -9,7 +9,7 @@ Simba 提供三种可插拔的分布式互斥锁存储后端。每种后端都�
 
 ## JDBC 后端
 
-JDBC 后端使用 MySQL 表（`simba_mutex`），通过 `version` 列实现乐观锁。争用由 `ScheduledThreadPoolExecutor` 通过轮询驱动。
+JDBC 后端使用 MySQL 表（`simba_mutex`），通过由 owner/transition 谓词守卫的原子条件 `UPDATE` 实现并发安全。争用由 `ScheduledThreadPoolExecutor` 通过轮询驱动。
 
 ### 表结构
 
@@ -34,13 +34,13 @@ erDiagram
         bigint ttl_at "Epoch millis: TTL expiry"
         bigint transition_at "Epoch millis: transition window end"
         char owner_id "Contender ID of current owner"
-        int version "Optimistic lock version counter"
+        int version "State change counter"
     }
 ```
 
-`MutexOwnerEntity` 类（[`JdbcMutexOwnerRepository.kt`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/MutexOwnerRepository.kt)）在 `MutexOwner` 的基础上扩展了 `version` 字段用于乐观锁，以及一个 `currentDbAt` 字段来捕获数据库服务器的当前时间戳，从而防止应用节点之间的时钟偏移问题。
+`MutexOwnerEntity` 类（[`JdbcMutexOwnerRepository.kt`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/MutexOwnerRepository.kt)）在 `MutexOwner` 的基础上扩展了 `version` 状态变更计数字段，以及一个 `currentDbAt` 字段来捕获数据库服务器的当前时间戳，从而防止应用节点之间的时钟偏移问题。
 
-### 原子获取（乐观锁）
+### 原子获取（条件更新）
 
 [`JdbcMutexOwnerRepository`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt#L43) 中的 `SQL_ACQUIRE` 查询执行带有两个条件的原子 `UPDATE ... WHERE`：
 
@@ -389,7 +389,7 @@ flowchart LR
 
 | 特性 | JDBC | Redis | Zookeeper |
 |---|---|---|---|
-| **获取机制** | `UPDATE ... WHERE` + 乐观锁 | `SET NX PX` 原子 Lua 脚本 | Curator `LeaderLatch`（临时顺序节点） |
+| **获取机制** | `UPDATE ... WHERE` + owner/transition 谓词守卫 | `SET NX PX` 原子 Lua 脚本 | Curator `LeaderLatch`（临时顺序节点） |
 | **通知方式** | 通过 `ScheduledThreadPoolExecutor` 轮询 | 发布/订阅即时通知 | ZNode 监听（内置于 Curator） |
 | **故障检测** | TTL 到期（轮询间隔） | 键 TTL 到期 + 发布/订阅 | 会话丢失时删除临时节点 |
 | **延迟** | 轮询间隔（通常基于 ttl） | 亚毫秒级（发布/订阅推送） | 会话超时（通常 5-30 秒） |

--- a/wiki/zh/architecture/index.md
+++ b/wiki/zh/architecture/index.md
@@ -233,7 +233,7 @@ flowchart LR
 | 模块 | 职责 |
 |---|---|
 | `simba-core` | 核心接口和抽象实现 |
-| `simba-jdbc` | JDBC/MySQL 后端 — 基于乐观锁的轮询 |
+| `simba-jdbc` | JDBC/MySQL 后端 — 基于原子条件更新的轮询 |
 | `simba-spring-redis` | Redis 后端 — Lua 脚本 + 发布/订阅通知 |
 | `simba-zookeeper` | Zookeeper 后端 — Curator LeaderLatch 配方 |
 | `simba-spring-boot-starter` | Spring Boot 自动配置 |

--- a/wiki/zh/index.md
+++ b/wiki/zh/index.md
@@ -19,7 +19,7 @@ hero:
 features:
   - icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
     title: 多种后端支持
-    details: "选择最适合你技术栈的存储方案：基于乐观锁的 JDBC/MySQL、基于原子 Lua 脚本和发布/订阅的 Redis，或基于 Apache Curator 的 Zookeeper。"
+    details: "选择最适合你技术栈的存储方案：基于原子条件更新的 JDBC/MySQL、基于原子 Lua 脚本和发布/订阅的 Redis，或基于 Apache Curator 的 Zookeeper。"
   - icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
     title: 领导者选举
     details: "自动化的所有权管理，支持可配置的 TTL 和过渡期。当前领导者在到期前续租；竞争者使用随机抖动等待，避免惊群效应。"

--- a/wiki/zh/modules/index.md
+++ b/wiki/zh/modules/index.md
@@ -71,7 +71,7 @@ graph TB
 | 模块 | 职责 | 关键类型 | 依赖 |
 |---|---|---|---|
 | **simba-core** | 核心接口、抽象类、值对象 | `MutexContender`、`MutexContendService`、`SimbaLocker`、`AbstractScheduler` | kotlin-logging、cosid-core、guava |
-| **simba-jdbc** | JDBC/MySQL 后端，使用乐观锁 | `JdbcMutexContendService`、`JdbcMutexOwnerRepository` | simba-core、JDBC 驱动 |
+| **simba-jdbc** | JDBC/MySQL 后端，使用原子条件更新 | `JdbcMutexContendService`、`JdbcMutexOwnerRepository` | simba-core、JDBC 驱动 |
 | **simba-spring-redis** | Redis 后端，使用 Lua 脚本和发布/订阅 | `SpringRedisMutexContendService`、Lua 脚本 | simba-core、spring-data-redis |
 | **simba-zookeeper** | Zookeeper 后端，使用 Curator LeaderLatch | `ZookeeperMutexContendService` | simba-core、curator-recipes |
 | **simba-spring-boot-starter** | 所有后端的自动配置 | `SimbaJdbcAutoConfiguration`、`SimbaSpringRedisAutoConfiguration`、`SimbaZookeeperAutoConfiguration` | simba-core + 条件性后端依赖 |
@@ -89,7 +89,7 @@ graph LR
 
         J_REPO["MutexOwnerRepository"]
         J_SCHED["ScheduledThreadPoolExecutor<br>(polling)"]
-        J_DDL["simba_mutex table<br>optimistic locking"]
+        J_DDL["simba_mutex table<br>conditional UPDATE"]
     end
     subgraph sg_88 ["Redis Backend"]
 
@@ -117,7 +117,7 @@ graph LR
 |---|---|---|---|
 | **协调机制** | 使用 `ScheduledThreadPoolExecutor` 轮询 | Lua 脚本 + 发布/订阅 | Curator `LeaderLatch` |
 | **锁存储** | `simba_mutex` 表 | Redis 键（`simba:{mutex}`） | ZNode（`/simba/{mutex}`） |
-| **所有权转移** | 通过 `version` 列进行乐观锁 | 有序集合等待队列 + 发布/订阅通知 | ZK 对 latch 参与者的 watcher |
+| **所有权转移** | 由 owner/transition 谓词守卫的原子条件 `UPDATE` | 有序集合等待队列 + 发布/订阅通知 | ZK 对 latch 参与者的 watcher |
 | **时间源** | MySQL `current_timestamp(3)` | 系统时钟（客户端侧） | ZK 服务器时间 |
 | **外部依赖** | MySQL 实例 | Redis 实例 | ZooKeeper 集群 |
 | **最适合** | 已有关系型数据库基础设施 | 高吞吐量、低延迟 | 强一致性保证 |

--- a/wiki/zh/modules/simba-jdbc.md
+++ b/wiki/zh/modules/simba-jdbc.md
@@ -1,11 +1,13 @@
 ---
 title: simba-jdbc 模块
-description: Simba 分布式互斥锁的 JDBC/MySQL 后端 -- 模式 DDL、乐观锁、基于轮询的竞争和自动配置属性。
+description: Simba 分布式互斥锁的 JDBC/MySQL 后端 -- 模式 DDL、原子条件更新、基于轮询的竞争和自动配置属性。
 ---
 
 # simba-jdbc 模块
 
-`simba-jdbc` 模块提供了基于 JDBC 的分布式互斥后端，使用 MySQL。它使用乐观锁（`version` 列）来确保对 `simba_mutex` 表的安全并发更新，并通过 `ScheduledThreadPoolExecutor` 轮询数据库以检测所有权变更。
+`simba-jdbc` 模块提供了基于 JDBC 的分布式互斥后端，使用 MySQL。它通过由 owner/transition 谓词守卫的原子条件 `UPDATE` 确保对 `simba_mutex` 表的并发安全，并通过 `ScheduledThreadPoolExecutor` 轮询数据库以检测所有权变更。
+
+> **MySQL 版本要求**：后端通过 `UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3))` 读取数据库时间。64 位平台的 MySQL 8.0.28+ 返回值有效期到 3001 年；更早版本的有效范围止于 2038-01-19 UTC，超范围调用返回 0，持有者时间戳会静默回退为 JVM 时钟。运行旧版本 MySQL 的部署请在此日期前规划升级。
 
 ## 模式 DDL
 
@@ -35,10 +37,10 @@ erDiagram
         bigint ttl_at "epoch millis -- TTL expiry"
         bigint transition_at "epoch millis -- grace period end"
         char owner_id "contender ID of current owner"
-        int version "optimistic lock version"
+        int version "state change counter"
     }
 
-    note for SIMBA_MUTEX "Each row represents one distributed mutex.<br>Optimistic locking via version column prevents<br>concurrent ownership conflicts."
+    note for SIMBA_MUTEX "Each row represents one distributed mutex.<br>Conditional UPDATE + InnoDB row lock prevents<br>concurrent ownership conflicts."
 ```
 
 ### 列语义
@@ -50,7 +52,7 @@ erDiagram
 | `ttl_at` | `BIGINT UNSIGNED` | TTL 到期的纪元毫秒时间戳。此后其他竞争者可以尝试获取。 |
 | `transition_at` | `BIGINT UNSIGNED` | 宽限期结束的纪元毫秒时间戳。等于 `acquired_at + ttl + transition`。 |
 | `owner_id` | `VARCHAR(128)` | 当前所有者的 `contenderId`。无所有者时为空字符串。 |
-| `version` | `INT UNSIGNED` | 每次获取/释放时递增，用于乐观并发控制。 |
+| `version` | `INT UNSIGNED` | 每次获取/释放时递增的状态变更计数器。不参与 `WHERE` 比较——并发由 owner/transition 谓词守卫。 |
 
 ## 关键类
 
@@ -129,7 +131,7 @@ class MutexOwnerEntity(
 
 | 字段 | 描述 |
 |---|---|
-| `version` | 来自数据库的乐观锁版本号。用于并发控制。 |
+| `version` | 来自数据库的状态变更计数器。不用于并发控制决策。 |
 | `currentDbAt` | 数据库服务器的当前时间戳，用于防止应用服务器之间的时钟偏移问题。 |
 
 ### JdbcMutexContendService
@@ -232,7 +234,7 @@ simba:
 | 场景 | 行为 |
 |---|---|
 | 互斥锁行不存在 | 抛出 `NotFoundMutexOwnerException`；使用 `tryInitMutex()` 或 `ensureOwner()` 自动创建 |
-| 并发获取冲突 | 通过 `version` 列进行乐观锁；`UPDATE` 返回 0 受影响行 |
+| 并发获取冲突 | 由 owner/transition 谓词守卫的原子条件 `UPDATE`；失败方 `UPDATE` 影响 0 行 |
 | 竞争期间 SQL 错误 | 以 ERROR 级别记录日志；下次竞争在 `ttl` 周期后调度 |
 | 事务回滚 | `acquireAndGetOwner` 在任何异常时回滚并包装为 `SimbaException` |
 

--- a/wiki/zh/testing/integration-testing.md
+++ b/wiki/zh/testing/integration-testing.md
@@ -66,7 +66,7 @@ CREATE TABLE IF NOT EXISTS simba_mutex (
 );
 ```
 
-`version` 列实现了并发获取尝试的乐观锁。[`JdbcMutexOwnerRepository`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt) 使用 `UPDATE ... WHERE version = ?` 确保每个周期只有一个竞争者成功。
+并发获取尝试由 owner/transition 谓词守卫的原子条件 `UPDATE` 串行化。[`JdbcMutexOwnerRepository`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexOwnerRepository.kt) 执行 `UPDATE ... WHERE mutex = ? AND (transition_at < now OR (owner_id = ? AND transition_at > now))`，InnoDB 行锁加谓词重评估确保每个周期只有一个竞争者成功。`version` 列是变更计数器——每次状态变更递增，从不比较。
 
 ### 测试类
 
@@ -114,7 +114,7 @@ autonumber
     C->>CS: start()
     CS->>CS: startContend() -> schedule(initialDelay)
     CS->>DB: acquireAndGetOwner(mutex, contenderId, ttl, transition)
-    DB->>DB: UPDATE WHERE version matches (optimistic lock)
+    DB->>DB: UPDATE guarded by owner/transition predicates
     DB-->>CS: MutexOwner (current state)
     CS->>CS: notifyOwner(mutexOwner)
     CS->>CS: nextDelay = contendPeriod.ensureNextDelay()


### PR DESCRIPTION
## Summary

Docs-only follow-up from the code review (findings #17/#21), EN and CN kept in sync.

### 1. Concurrency mechanism wording (#21)

The wiki claimed "optimistic locking via the `version` column" and `integration-testing.md` even quoted `UPDATE ... WHERE version = ?` — SQL that does not exist. In the implementation the `version` column is incremented on every state change but **never compared**; concurrent acquisition is guarded by the owner/transition predicates in a single conditional `UPDATE`, serialized by the InnoDB row lock. 38 occurrences across 12 files (EN + ZH, including mermaid ER diagrams, sequence diagrams, and comparison tables) now describe the actual mechanism.

### 2. MySQL version floor (#17)

The `simba-jdbc` module pages (EN + ZH) now document the DB-time constraint: `UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3))` is valid through year 3001 on 64-bit MySQL 8.0.28+, while older versions cap the valid range at 2038-01-19 UTC — beyond that the call returns 0 and owner timestamps silently fall back to JVM time. Deployments on older MySQL should plan an upgrade before 2038.

## Test plan

- [x] `pnpm run build` in `wiki/` — VitePress build + mermaid validation pass