### PR TITLE
feat: contender validation and deterministic starter backend selection

### DIFF
--- a/simba-core/src/main/kotlin/me/ahoo/simba/core/AbstractMutexContender.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/core/AbstractMutexContender.kt
@@ -25,11 +25,29 @@ abstract class AbstractMutexContender(
 ) : MutexContender {
     companion object {
         private val log = KotlinLogging.logger {}
+
+        /**
+         * Aligned with the strictest backend schema (simba_jdbc: `mutex varchar(66)`, `owner_id varchar(128)`).
+         */
+        const val MAX_MUTEX_LENGTH = 66
+        const val MAX_CONTENDER_ID_LENGTH = 128
+
+        /**
+         * Owner-event / acquire-result wire delimiter: a contenderId containing it breaks the redis protocol parsing.
+         */
+        const val CONTENDER_ID_DELIMITER = "@@"
     }
 
     init {
         require(mutex.isNotBlank()) { "mutex must not be blank!" }
+        require(mutex.length <= MAX_MUTEX_LENGTH) { "mutex must not exceed $MAX_MUTEX_LENGTH characters!" }
         require(contenderId.isNotBlank()) { "contenderId must not be blank!" }
+        require(contenderId.length <= MAX_CONTENDER_ID_LENGTH) {
+            "contenderId must not exceed $MAX_CONTENDER_ID_LENGTH characters!"
+        }
+        require(!contenderId.contains(CONTENDER_ID_DELIMITER)) {
+            "contenderId must not contain [$CONTENDER_ID_DELIMITER]!"
+        }
     }
 
     override fun onAcquired(mutexState: MutexState) {

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexContenderTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexContenderTest.kt
@@ -51,6 +51,34 @@ class AbstractMutexContenderTest {
     }
 
     @Test
+    fun `rejects mutex longer than 66 characters`() {
+        val error = assertThrows<IllegalArgumentException> { newContender("m".repeat(67)) }
+        assertThat(error.message, equalTo("mutex must not exceed 66 characters!"))
+    }
+
+    @Test
+    fun `accepts mutex of exactly 66 characters`() {
+        newContender("m".repeat(66))
+    }
+
+    @Test
+    fun `rejects contenderId longer than 128 characters`() {
+        val error = assertThrows<IllegalArgumentException> { newContender("m", "c".repeat(129)) }
+        assertThat(error.message, equalTo("contenderId must not exceed 128 characters!"))
+    }
+
+    @Test
+    fun `accepts contenderId of exactly 128 characters`() {
+        newContender("m", "c".repeat(128))
+    }
+
+    @Test
+    fun `rejects contenderId containing the owner event delimiter`() {
+        val error = assertThrows<IllegalArgumentException> { newContender("m", "c1@@c2") }
+        assertThat(error.message, equalTo("contenderId must not contain [@@]!"))
+    }
+
+    @Test
     fun `default contenderId is generated host format`() {
         val contender = object : AbstractMutexContender("m") {}
         assertThat(contender.contenderId, not(blankOrNullString()))

--- a/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfiguration.kt
+++ b/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfiguration.kt
@@ -16,9 +16,12 @@ import me.ahoo.simba.core.MutexContendServiceFactory
 import me.ahoo.simba.jdbc.JdbcMutexContendServiceFactory
 import me.ahoo.simba.jdbc.JdbcMutexOwnerRepository
 import me.ahoo.simba.jdbc.MutexOwnerRepository
+import me.ahoo.simba.spring.boot.starter.redis.SimbaSpringRedisAutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import java.util.concurrent.ForkJoinPool
@@ -29,7 +32,7 @@ import javax.sql.DataSource
  *
  * @author ahoo wang
  */
-@AutoConfiguration
+@AutoConfiguration(after = [SimbaSpringRedisAutoConfiguration::class])
 @ConditionalOnSimbaJdbcEnabled
 @ConditionalOnClass(
     JdbcMutexContendServiceFactory::class
@@ -38,12 +41,14 @@ import javax.sql.DataSource
 class SimbaJdbcAutoConfiguration(private val jdbcProperties: JdbcProperties) {
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnSingleCandidate(DataSource::class)
     fun mutexOwnerRepository(dataSource: DataSource): MutexOwnerRepository {
         return JdbcMutexOwnerRepository(dataSource)
     }
 
     @Bean
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(MutexContendServiceFactory::class)
+    @ConditionalOnBean(MutexOwnerRepository::class)
     fun jdbcMutexContendServiceFactory(mutexOwnerRepository: MutexOwnerRepository): MutexContendServiceFactory {
         return JdbcMutexContendServiceFactory(
             mutexOwnerRepository = mutexOwnerRepository,

--- a/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/redis/SimbaSpringRedisAutoConfiguration.kt
+++ b/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/redis/SimbaSpringRedisAutoConfiguration.kt
@@ -52,8 +52,8 @@ class SimbaSpringRedisAutoConfiguration(private val redisProperties: RedisProper
     }
 
     @Bean(destroyMethod = "close")
-    @ConditionalOnMissingBean
-    @ConditionalOnBean(StringRedisTemplate::class)
+    @ConditionalOnMissingBean(MutexContendServiceFactory::class)
+    @ConditionalOnBean(StringRedisTemplate::class, RedisMessageListenerContainer::class)
     fun redisMutexContendServiceFactory(
         redisTemplate: StringRedisTemplate,
         listenerContainer: RedisMessageListenerContainer

--- a/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/zookeeper/SimbaZookeeperAutoConfiguration.kt
+++ b/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/zookeeper/SimbaZookeeperAutoConfiguration.kt
@@ -12,6 +12,8 @@
  */
 package me.ahoo.simba.spring.boot.starter.zookeeper
 
+import me.ahoo.simba.core.MutexContendServiceFactory
+import me.ahoo.simba.spring.boot.starter.jdbc.SimbaJdbcAutoConfiguration
 import me.ahoo.simba.zookeeper.ZookeeperMutexContendServiceFactory
 import org.apache.curator.framework.CuratorFramework
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -27,7 +29,7 @@ import java.util.concurrent.ForkJoinPool
  *
  * @author ahoo wang
  */
-@AutoConfiguration
+@AutoConfiguration(after = [SimbaJdbcAutoConfiguration::class])
 @ConditionalOnSimbaZookeeperEnabled
 @ConditionalOnClass(
     ZookeeperMutexContendServiceFactory::class
@@ -36,7 +38,7 @@ import java.util.concurrent.ForkJoinPool
 class SimbaZookeeperAutoConfiguration {
     @Bean
     @ConditionalOnBean(CuratorFramework::class)
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(MutexContendServiceFactory::class)
     fun zookeeperMutexContendServiceFactory(curatorFramework: CuratorFramework): ZookeeperMutexContendServiceFactory {
         return ZookeeperMutexContendServiceFactory(ForkJoinPool.commonPool(), curatorFramework)
     }

--- a/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/MultipleBackendsAutoConfigurationTest.kt
+++ b/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/MultipleBackendsAutoConfigurationTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.spring.boot.starter
+
+import io.mockk.mockk
+import me.ahoo.simba.core.MutexContendServiceFactory
+import me.ahoo.simba.spring.boot.starter.jdbc.SimbaJdbcAutoConfiguration
+import me.ahoo.simba.spring.boot.starter.redis.SimbaSpringRedisAutoConfiguration
+import me.ahoo.simba.spring.boot.starter.zookeeper.SimbaZookeeperAutoConfiguration
+import me.ahoo.simba.spring.redis.SpringRedisMutexContendServiceFactory
+import org.apache.curator.framework.CuratorFramework
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import javax.sql.DataSource
+
+/**
+ * When multiple backends are on the classpath, exactly one contend service factory
+ * must be registered, following the documented selection order
+ * Redis -> JDBC -> Zookeeper.
+ */
+internal class MultipleBackendsAutoConfigurationTest {
+    private val contextRunner = ApplicationContextRunner()
+        .withBean(DataSource::class.java, { mockk() })
+        .withBean(StringRedisTemplate::class.java, { mockk(relaxed = true) })
+        .withBean(RedisMessageListenerContainer::class.java, { mockk(relaxed = true) })
+        .withBean(CuratorFramework::class.java, { mockk(relaxed = true) })
+        .withConfiguration(
+            AutoConfigurations.of(
+                SimbaJdbcAutoConfiguration::class.java,
+                SimbaSpringRedisAutoConfiguration::class.java,
+                SimbaZookeeperAutoConfiguration::class.java
+            )
+        )
+
+    @Test
+    fun redisTakesPrecedenceOverJdbcAndZookeeper() {
+        contextRunner.run {
+            assertThat(it).hasSingleBean(MutexContendServiceFactory::class.java)
+            assertThat(it).getBean(MutexContendServiceFactory::class.java)
+                .isInstanceOf(SpringRedisMutexContendServiceFactory::class.java)
+        }
+    }
+
+    @Test
+    fun jdbcTakesPrecedenceOverZookeeperWhenRedisAbsent() {
+        contextRunner
+            .withPropertyValues("simba.redis.enabled=false")
+            .run {
+                assertThat(it).hasSingleBean(MutexContendServiceFactory::class.java)
+                assertThat(it).getBean(MutexContendServiceFactory::class.java)
+                    .isInstanceOf(me.ahoo.simba.jdbc.JdbcMutexContendServiceFactory::class.java)
+            }
+    }
+}

--- a/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfigurationTest.kt
+++ b/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfigurationTest.kt
@@ -78,4 +78,16 @@ internal class SimbaJdbcAutoConfigurationTest {
                     .doesNotHaveBean(MutexContendServiceFactory::class.java)
             }
     }
+
+    @Test
+    fun contextWithoutDataSourceSkipsJdbcBeans() {
+        contextRunner
+            .withUserConfiguration(SimbaJdbcAutoConfiguration::class.java)
+            .run {
+                assertThat(it)
+                    .hasSingleBean(SimbaJdbcAutoConfiguration::class.java)
+                    .doesNotHaveBean(MutexOwnerRepository::class.java)
+                    .doesNotHaveBean(MutexContendServiceFactory::class.java)
+            }
+    }
 }

--- a/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/redis/SimbaSpringRedisAutoConfigurationTest.kt
+++ b/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/redis/SimbaSpringRedisAutoConfigurationTest.kt
@@ -12,11 +12,13 @@
  */
 package me.ahoo.simba.spring.boot.starter.redis
 
+import io.mockk.mockk
 import me.ahoo.simba.core.MutexContendServiceFactory
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
 
 /**
@@ -40,6 +42,19 @@ internal class SimbaSpringRedisAutoConfigurationTest {
                     .hasSingleBean(RedisProperties::class.java)
                     .hasSingleBean(RedisMessageListenerContainer::class.java)
                     .hasSingleBean(MutexContendServiceFactory::class.java)
+            }
+    }
+
+    @Test
+    fun contextWithoutListenerContainerSkipsFactoryBean() {
+        contextRunner
+            .withBean(StringRedisTemplate::class.java, { mockk(relaxed = true) })
+            .withUserConfiguration(SimbaSpringRedisAutoConfiguration::class.java)
+            .run {
+                assertThat(it)
+                    .hasSingleBean(SimbaSpringRedisAutoConfiguration::class.java)
+                    .doesNotHaveBean(RedisMessageListenerContainer::class.java)
+                    .doesNotHaveBean(MutexContendServiceFactory::class.java)
             }
     }
 }

--- a/wiki/modules/simba-spring-boot-starter.md
+++ b/wiki/modules/simba-spring-boot-starter.md
@@ -19,6 +19,10 @@ me.ahoo.simba.spring.boot.starter.redis.SimbaSpringRedisAutoConfiguration
 me.ahoo.simba.spring.boot.starter.zookeeper.SimbaZookeeperAutoConfiguration
 ```
 
+### Backend Selection Order
+
+Enable exactly **one** backend per application. If several backends end up on the classpath at once, the auto-configurations are applied in a deterministic order — **Redis, then JDBC, then Zookeeper** — and the first backend whose required beans are present registers its `MutexContendServiceFactory`; the others back off through `@ConditionalOnMissingBean(MutexContendServiceFactory.class)`.
+
 ## Configuration Flow
 
 ```mermaid
@@ -373,6 +377,8 @@ simba:
   zookeeper:
     enabled: false
 ```
+
+Explicitly enabling a single backend (as above) is the recommended setup. When multiple backends are enabled simultaneously, the [backend selection order](#backend-selection-order) applies (Redis > JDBC > Zookeeper) and only the first available one is activated.
 
 ## See Also
 

--- a/wiki/zh/modules/simba-spring-boot-starter.md
+++ b/wiki/zh/modules/simba-spring-boot-starter.md
@@ -19,6 +19,10 @@ me.ahoo.simba.spring.boot.starter.redis.SimbaSpringRedisAutoConfiguration
 me.ahoo.simba.spring.boot.starter.zookeeper.SimbaZookeeperAutoConfiguration
 ```
 
+### 后端选择顺序
+
+每个应用应只启用**一个**后端。若多个后端同时出现在 classpath 上，自动配置按确定性顺序应用——**Redis、JDBC、Zookeeper**——第一个所需 bean 齐备的后端注册其 `MutexContendServiceFactory`，其余后端通过 `@ConditionalOnMissingBean(MutexContendServiceFactory.class)` 退避。
+
 ## 配置流程
 
 ```mermaid
@@ -373,6 +377,8 @@ simba:
   zookeeper:
     enabled: false
 ```
+
+如上显式启用单一后端是推荐用法。多个后端同时启用时，按[后端选择顺序](#后端选择顺序)（Redis > JDBC > Zookeeper）仅激活第一个可用后端。
 
 ## 另请参阅
 


### PR DESCRIPTION
## Summary

Fifth batch, implementing the decisions taken for review findings **#11/#12/#13/#19** (starter condition semantics, multi-backend ordering, core input validation). Every behavior change has a RED-verified regression test.

### 1. `feat(core)`: contender construction validation (#19 — core-level, per decision)

Only blankness was checked before: an over-long mutex/contenderId failed late with an opaque MySQL 1406 on the JDBC backend, and a contenderId containing `@@` broke the Redis wire-protocol parsing. Construction now fail-fasts:
- `mutex.length <= 66`, `contenderId.length <= 128` (constants, aligned with the strictest backend schema), and
- contenderId must not contain the `@@` owner-event delimiter.

Six new test cases including exact-boundary accepts; all backend suites stay green.

### 2. `fix(starter)`: Boot-convention conditions (#11/#12 — align-with-Boot, per decision)

- JDBC repository bean: `@ConditionalOnSingleCandidate(DataSource)` — a missing/no-unique DataSource now **skips** the backend instead of failing startup with `NoSuchBeanDefinitionException`; the factory bean additionally requires the repository bean.
- Redis factory bean: guarded by `@ConditionalOnBean(RedisMessageListenerContainer)` — a custom `StringRedisTemplate` without a single connection factory no longer crashes startup.
- Regression tests: no-DataSource context skips beans; no-container context skips the factory. Both RED pre-fix (verified the failures were the intended `NoSuchBeanDefinitionException`s).

### 3. `fix(starter)`: deterministic multi-backend selection (#13 — explicit ordering, per decision)

The RED run of the new precedence tests exposed an extra defect: with multiple backends present the factory beans could **coexist** — the Zookeeper factory's `@ConditionalOnMissingBean` inferred its concrete type and never saw the interface-typed factories. All three factories now declare `@ConditionalOnMissingBean(MutexContendServiceFactory)`, and the auto-configurations are explicitly ordered **Redis → JDBC → Zookeeper**. Precedence tests (via `AutoConfigurations.of`, which applies the real sorter) verify redis-over-jdbc/zookeeper and jdbc-over-zookeeper.

### 4. `docs(wiki)`: backend selection order documented (EN + ZH)

Single-backend as recommendation; coexistence selects Redis > JDBC > Zookeeper.

## Test plan

- [x] `simba-core:check`, `simba-spring-boot-starter:check` (incl. 8 new tests) — green
- [x] `simba-zookeeper:test`, `simba-spring-redis:test` — green (validation is non-breaking for existing names)
- [x] `simba-jdbc` unit tests — green; MySQL integration via CI
- [x] wiki `pnpm run build` — green