### PR TITLE
fix(core): serialize owner notifications by lifecycle

### DIFF
--- a/simba-core/src/main/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalService.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalService.kt
@@ -12,10 +12,12 @@
  */
 package me.ahoo.simba.core
 
+import com.google.common.util.concurrent.MoreExecutors
 import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.simba.core.MutexRetrievalService.Status
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
 
 /**
@@ -50,6 +52,8 @@ abstract class AbstractMutexRetrievalService protected constructor(
      * owner and dispatch duplicate owner-change events for one transition.
      */
     private val notifyLock = Any()
+    private val notifyExecutor = MoreExecutors.newSequentialExecutor(handleExecutor)
+    private val lifecycleGeneration = AtomicLong()
 
     protected fun resetOwner() {
         mutexState = MutexState.NONE
@@ -60,8 +64,11 @@ abstract class AbstractMutexRetrievalService protected constructor(
         log.info {
             "start - mutex:[${retriever.mutex}] - status:[$status]"
         }
-        check(STATUS.compareAndSet(this, Status.INITIAL, Status.STARTING)) {
-            "Cannot start from state [$status]. Expected: [${Status.INITIAL}]"
+        synchronized(notifyLock) {
+            check(STATUS.compareAndSet(this, Status.INITIAL, Status.STARTING)) {
+                "Cannot start from state [$status]. Expected: [${Status.INITIAL}]"
+            }
+            lifecycleGeneration.incrementAndGet()
         }
         try {
             startRetrieval()
@@ -76,24 +83,30 @@ abstract class AbstractMutexRetrievalService protected constructor(
     protected abstract fun stopRetrieval()
 
     protected fun notifyOwner(newOwner: MutexOwner): CompletableFuture<Void> {
-        return CompletableFuture.runAsync({ safeNotifyOwner(newOwner) }, handleExecutor)
+        val generation = lifecycleGeneration.get()
+        return CompletableFuture.runAsync({ safeNotifyOwner(newOwner, generation) }, notifyExecutor)
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun safeNotifyOwner(newOwner: MutexOwner) {
+    private fun safeNotifyOwner(newOwner: MutexOwner, generation: Long) {
         try {
             /*
              * Concurrency issues.
              * Order of assignment is very important.
              */
             synchronized(notifyLock) {
+                if (generation != lifecycleGeneration.get()) {
+                    log.warn {
+                        "safeNotifyOwner - ignore - mutex:[${retriever.mutex}] - newOwner:[$newOwner] belongs to a previous lifecycle."
+                    }
+                    return
+                }
                 /*
-                 * A notification submitted while active may execute after stop() completed
-                 * (out-of-order dispatch on a multi-threaded handleExecutor). Once INITIAL,
-                 * only a release notification (NONE) may still be applied — the stop-release
-                 * contract depends on it — while any claim of ownership is stale and dropped.
+                 * A notification submitted while active may execute after stop() completes.
+                 * Once inactive, only a release notification (NONE) may still be applied —
+                 * the stop-release contract depends on it — while any ownership claim is stale.
                  */
-                if (Status.INITIAL == status && newOwner.ownerId.isNotBlank()) {
+                if (!status.isActive && newOwner.ownerId.isNotBlank()) {
                     log.warn {
                         "safeNotifyOwner - ignore - mutex:[${retriever.mutex}] - newOwner:[$newOwner] is not active[$status]."
                     }
@@ -114,8 +127,10 @@ abstract class AbstractMutexRetrievalService protected constructor(
         log.info {
             "stop - mutex:[${retriever.mutex}] - status:[$status]"
         }
-        check(STATUS.compareAndSet(this, Status.RUNNING, Status.STOPPING)) {
-            "Cannot stop mutex:[${retriever.mutex}] from state:[$status]. Expected:[${Status.RUNNING}]"
+        synchronized(notifyLock) {
+            check(STATUS.compareAndSet(this, Status.RUNNING, Status.STOPPING)) {
+                "Cannot stop mutex:[${retriever.mutex}] from state:[$status]. Expected:[${Status.RUNNING}]"
+            }
         }
         try {
             stopRetrieval()

--- a/simba-core/src/main/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalService.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalService.kt
@@ -135,6 +135,7 @@ abstract class AbstractMutexRetrievalService protected constructor(
         try {
             stopRetrieval()
         } finally {
+            safeNotifyOwner(MutexOwner.NONE, lifecycleGeneration.get())
             STATUS.set(this, Status.INITIAL)
         }
     }

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
@@ -18,9 +18,8 @@ import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.sameInstance
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.util.concurrent.CountDownLatch
+import java.util.ArrayDeque
 import java.util.concurrent.Executor
-import kotlin.concurrent.thread
 
 class AbstractMutexRetrievalServiceTest {
     private fun newService(): FakeMutexContendService {
@@ -154,28 +153,20 @@ class AbstractMutexRetrievalServiceTest {
 
     @Test
     fun `concurrent duplicate owner notifications dispatch onAcquired at most once`() {
-        // The read->write window inside safeNotifyOwner is nanoseconds wide, so a single
-        // barrier-paired pair rarely interleaves; thousands of attempts make hitting the
-        // window a statistical certainty before the fix, while the fix passes deterministically.
-        for (attempt in 0 until 5000) {
-            val contender = ConcurrentCountingContender("m", "c1-$attempt")
-            val service = FakeMutexContendService(contender, BarrierPairExecutor())
-            val selfOwner = MutexOwner(contender.contenderId, 0, Long.MAX_VALUE, Long.MAX_VALUE)
-            // notifications are only meaningful while the service is active
-            service.start()
+        val contender = FakeMutexContender("m", "c1")
+        val executor = ManualExecutor()
+        val service = FakeMutexContendService(contender, executor)
+        val selfOwner = MutexOwner(contender.contenderId, 0, Long.MAX_VALUE, Long.MAX_VALUE)
+        service.start()
 
-            val first = service.publishOwner(selfOwner)
-            val second = service.publishOwner(selfOwner)
-            first.join()
-            second.join()
+        val first = service.publishOwner(selfOwner)
+        val second = service.publishOwner(selfOwner)
+        executor.runAll()
+        first.join()
+        second.join()
 
-            assertThat(
-                "attempt [$attempt]: duplicate onAcquired dispatched for a single NONE->self transition",
-                contender.acquiredCount.get(),
-                equalTo(1)
-            )
-            service.stop()
-        }
+        assertThat(contender.acquired.size, equalTo(1))
+        service.stop()
     }
 
     @Test
@@ -197,7 +188,7 @@ class AbstractMutexRetrievalServiceTest {
     @Test
     fun `self notification submitted while active but executing after stop must not revive ownership`() {
         val contender = FakeMutexContender("m", "c1")
-        val executor = GatedExecutor()
+        val executor = ManualExecutor()
         val service = FakeMutexContendService(contender, executor)
         service.start()
 
@@ -207,7 +198,7 @@ class AbstractMutexRetrievalServiceTest {
         service.stop()
         assertThat(service.status, equalTo(MutexRetrievalService.Status.INITIAL))
 
-        executor.release()
+        executor.runAll()
         future.join()
 
         assertThat(service.mutexState, equalTo(MutexState.NONE))
@@ -217,10 +208,12 @@ class AbstractMutexRetrievalServiceTest {
     @Test
     fun `stop release notification executing after stop must still be applied`() {
         val contender = FakeMutexContender("m", "c1")
-        val executor = GatedExecutor()
+        val executor = ManualExecutor()
         val service = FakeMutexContendService(contender, executor)
         service.start()
-        service.publishOwner(MutexOwner("c1", 0, 100, 200)).join()
+        val acquisition = service.publishOwner(MutexOwner("c1", 0, 100, 200))
+        executor.runAll()
+        acquisition.join()
         assertThat(service.hasOwner(), equalTo(true))
 
         // the release notification is submitted while stopping and may execute once the
@@ -228,25 +221,70 @@ class AbstractMutexRetrievalServiceTest {
         val future = service.publishOwner(MutexOwner.NONE)
         service.stop()
 
-        executor.release()
+        executor.runAll()
         future.join()
 
         assertThat(service.mutexState.after, equalTo(MutexOwner.NONE))
         assertThat(contender.released.size, equalTo(1))
     }
 
-    private class GatedExecutor : Executor {
-        private val gate = CountDownLatch(1)
+    @Test
+    fun `owner notifications are applied in submission order`() {
+        val contender = FakeMutexContender("m", "c1")
+        val executor = ManualExecutor()
+        val service = FakeMutexContendService(contender, executor)
+        val owner = MutexOwner("c1", 0, Long.MAX_VALUE, Long.MAX_VALUE)
+        service.start()
+
+        val acquired = service.publishOwner(owner)
+        val released = service.publishOwner(MutexOwner.NONE)
+
+        executor.runAllInReverseOrder()
+        acquired.join()
+        released.join()
+
+        assertThat(service.afterOwner, sameInstance(MutexOwner.NONE))
+        assertThat(contender.acquired.size, equalTo(1))
+        assertThat(contender.released.size, equalTo(1))
+        service.stop()
+    }
+
+    @Test
+    fun `owner notification from previous lifecycle is ignored after restart`() {
+        val contender = FakeMutexContender("m", "c1")
+        val executor = ManualExecutor()
+        val service = FakeMutexContendService(contender, executor)
+        service.start()
+
+        val stale = service.publishOwner(MutexOwner("c1", 0, Long.MAX_VALUE, Long.MAX_VALUE))
+        service.stop()
+        service.start()
+
+        executor.runAll()
+        stale.join()
+
+        assertThat(service.mutexState, equalTo(MutexState.NONE))
+        assertThat(contender.acquired.size, equalTo(0))
+        service.stop()
+    }
+
+    private class ManualExecutor : Executor {
+        private val tasks = ArrayDeque<Runnable>()
 
         override fun execute(command: Runnable) {
-            thread(isDaemon = true) {
-                gate.await()
-                command.run()
+            tasks.addLast(command)
+        }
+
+        fun runAll() {
+            while (tasks.isNotEmpty()) {
+                tasks.removeFirst().run()
             }
         }
 
-        fun release() {
-            gate.countDown()
+        fun runAllInReverseOrder() {
+            while (tasks.isNotEmpty()) {
+                tasks.removeLast().run()
+            }
         }
     }
 }

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
@@ -229,6 +229,26 @@ class AbstractMutexRetrievalServiceTest {
     }
 
     @Test
+    fun `stop release notification is preserved across restart`() {
+        val contender = FakeMutexContender("m", "c1")
+        val executor = ManualExecutor()
+        val service = FakeMutexContendService(contender, executor)
+        service.start()
+        val acquisition = service.publishOwner(MutexOwner("c1", 0, 100, 200))
+        executor.runAll()
+        acquisition.join()
+
+        val release = service.publishOwner(MutexOwner.NONE)
+        service.stop()
+        service.start()
+        executor.runAll()
+        release.join()
+
+        assertThat(contender.released.size, equalTo(1))
+        service.stop()
+    }
+
+    @Test
     fun `owner notifications are applied in submission order`() {
         val contender = FakeMutexContender("m", "c1")
         val executor = ManualExecutor()

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/TestDoubles.kt
@@ -14,11 +14,7 @@
 package me.ahoo.simba.core
 
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.Executor
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.concurrent.thread
 
 /**
  * [MutexOwner] with a fixed [currentAt] for deterministic time-based tests.
@@ -67,40 +63,6 @@ object SameThreadExecutor : Executor {
     override fun execute(command: Runnable) {
         command.run()
     }
-}
-
-/**
- * Executor that pairs two submitted tasks at a barrier and then runs each on its
- * own thread, so both notifications enter [AbstractMutexRetrievalService.safeNotifyOwner]
- * at the same instant — a deterministic stand-in for a multi-threaded handleExecutor
- * (the production default is ForkJoinPool.commonPool).
- */
-class BarrierPairExecutor : Executor {
-    private val barrier = CyclicBarrier(2)
-
-    override fun execute(command: Runnable) {
-        thread(isDaemon = true) {
-            runCatching { barrier.await(10, TimeUnit.SECONDS) }
-            command.run()
-        }
-    }
-}
-
-/**
- * [MutexContender] that counts [onAcquired] calls atomically.
- * Unlike [FakeMutexContender] this is safe under concurrent notification.
- */
-class ConcurrentCountingContender(
-    override val mutex: String,
-    override val contenderId: String
-) : MutexContender {
-    val acquiredCount = AtomicInteger()
-
-    override fun onAcquired(mutexState: MutexState) {
-        acquiredCount.incrementAndGet()
-    }
-
-    override fun onReleased(mutexState: MutexState) = Unit
 }
 
 /**


### PR DESCRIPTION
## What changed

- serialize owner notifications per service with Guava's existing sequential executor
- reject queued notifications from previous start/stop lifecycles
- linearize stop transitions with owner notification state updates
- replace probabilistic/barrier-based tests with deterministic manual-executor coverage

## Root cause

`CompletableFuture.runAsync` submitted every owner event independently to a multi-threaded executor. The existing lock prevented simultaneous state writes but did not preserve event order, and queued events had no lifecycle identity. As a result, a stale claim or release could overwrite the current state after stop/restart.

## Validation

- `./gradlew :simba-core:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `./gradlew :simba-zookeeper:check :simba-spring-redis:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `./gradlew :simba-jdbc:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1` with MySQL 8.0 Docker
- `git diff --check`

No public API signatures or dependencies changed.