### PR TITLE
fix(core): clean up failed locker acquisition

### DIFF
--- a/simba-core/src/main/kotlin/me/ahoo/simba/locker/SimbaLocker.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/locker/SimbaLocker.kt
@@ -57,11 +57,14 @@ class SimbaLocker(
 
     @Throws(Exception::class)
     override fun close() {
-        contendService.stop()
+        if (contendService.running) {
+            contendService.stop()
+        }
+        OWNER.set(this, null)
     }
 
     override fun acquire() {
-        if (OWNER.compareAndSet(this, null, Thread.currentThread())) {
+        acquireOwned {
             contendService.start()
             var interrupted = false
             /*
@@ -79,14 +82,12 @@ class SimbaLocker(
             if (interrupted) {
                 Thread.currentThread().interrupt()
             }
-        } else {
-            throw IllegalMonitorStateException("Thread[${OWNER.get(this)}] already owns this lock[$mutex].")
         }
     }
 
     @Throws(TimeoutException::class)
     override fun acquire(timeout: Duration) {
-        if (OWNER.compareAndSet(this, null, Thread.currentThread())) {
+        acquireOwned {
             contendService.start()
             val deadline = System.nanoTime() + timeout.toNanos()
             var interrupted = false
@@ -108,13 +109,35 @@ class SimbaLocker(
                     "Could not acquire [$contenderId]@mutex:[$mutex] within timeout of ${timeout.toMillis()}ms"
                 )
             }
-        } else {
-            throw IllegalMonitorStateException("Thread[${OWNER.get(this)}] already owns this lock[$mutex].")
         }
     }
 
     override fun onAcquired(mutexState: MutexState) {
         super.onAcquired(mutexState)
         LockSupport.unpark(OWNER[this])
+    }
+
+    private inline fun acquireOwned(acquire: () -> Unit) {
+        if (!OWNER.compareAndSet(this, null, Thread.currentThread())) {
+            throw IllegalMonitorStateException("Thread[${OWNER.get(this)}] already owns this lock[$mutex].")
+        }
+        try {
+            acquire()
+        } catch (error: Throwable) {
+            cleanupFailedAcquire(error)
+        }
+    }
+
+    private fun cleanupFailedAcquire(error: Throwable): Nothing {
+        try {
+            if (contendService.running) {
+                contendService.stop()
+            }
+        } catch (cleanupError: Throwable) {
+            error.addSuppressed(cleanupError)
+        } finally {
+            OWNER.compareAndSet(this, Thread.currentThread(), null)
+        }
+        throw error
     }
 }

--- a/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
@@ -39,7 +39,12 @@ import kotlin.concurrent.thread
 private class ControllableContendService(
     contender: MutexContender
 ) : AbstractMutexContendService(contender, SameThreadExecutor) {
-    override fun startContend() = Unit
+    var startFailure: Throwable? = null
+
+    override fun startContend() {
+        startFailure?.let { throw it }
+    }
+
     override fun stopContend() = Unit
 
     fun markOwner(ownerId: String) {
@@ -73,6 +78,38 @@ class SimbaLockerTest {
         }
         assertThat(error.message, containsString("Could not acquire"))
         assertThat(error.message, containsString("within timeout of 50ms"))
+    }
+
+    @Test
+    fun `timed out acquire cleans up so same locker can retry`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        assertThrows<TimeoutException> {
+            locker.acquire(Duration.ofMillis(1))
+        }
+
+        assertThrows<TimeoutException> {
+            locker.acquire(Duration.ofMillis(1))
+        }
+    }
+
+    @Test
+    fun `start failure clears local owner so acquire can retry`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+        val failure = IllegalStateException("boom")
+        factory.service!!.startFailure = failure
+
+        val error = assertThrows<IllegalStateException> {
+            locker.acquire()
+        }
+        assertThat(error, equalTo(failure))
+
+        factory.service!!.startFailure = null
+        assertThrows<TimeoutException> {
+            locker.acquire(Duration.ofMillis(1))
+        }
     }
 
     @Test
@@ -168,12 +205,12 @@ class SimbaLockerTest {
     }
 
     @Test
-    fun `close throws IllegalStateException when contend service not running`() {
+    fun `close is idempotent when contend service is not running`() {
         val factory = ControllableFactory()
         val locker = SimbaLocker("m", factory)
 
-        val error = assertThrows<IllegalStateException> { locker.close() }
-        assertThat(error.message, containsString("Cannot stop mutex:[m]"))
+        locker.close()
+        locker.close()
     }
 
     /**


### PR DESCRIPTION
## What changed

- stop an active contention service when timed acquisition fails
- clear the local locker owner after timeout or start failure so the instance can retry
- make `close()` idempotent so try-with-resources/`use` can safely close after failure cleanup
- preserve the original acquisition error and attach cleanup failures as suppressed exceptions
- cover timeout, start-failure retry, and repeated close behavior

## Root cause

`SimbaLocker` claimed its local `OWNER` before starting contention, but failure paths never stopped contention or released that local claim. A timed-out call could therefore acquire the distributed lock later, while every retry on the same locker failed with `IllegalMonitorStateException`. Once failure cleanup stops contention, RAII invokes `close()` again, so close must also tolerate an already-stopped service.

## Validation

- `./gradlew :simba-core:test --tests me.ahoo.simba.locker.SimbaLockerTest --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `./gradlew :simba-core:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `git diff --check agent/core-owner-notification-order..HEAD`

## Dependency

Stacked on #449 because that PR fixes a pre-existing core test deadlock. Retarget this PR to `main` after #449 merges.
