### PR TITLE
fix(jdbc): compensate post-stop acquisition

### DIFF
--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
@@ -23,6 +23,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Jdbc Mutex Contend Service.
@@ -43,21 +44,23 @@ class JdbcMutexContendService(
 
     private var executorService: ScheduledThreadPoolExecutor? = null
     private val contendPeriod: ContendPeriod = ContendPeriod(contenderId)
+    private val lifecycleGeneration = AtomicLong()
 
     @Volatile
     private var contendScheduledFuture: ScheduledFuture<*>? = null
 
     override fun startContend() {
+        val generation = lifecycleGeneration.incrementAndGet()
         executorService =
             ScheduledThreadPoolExecutor(1, defaultFactory("JdbcSimba_${mutex}_$contenderId"))
-        nextSchedule(initialDelay.toMillis())
+        nextSchedule(initialDelay.toMillis(), generation)
     }
 
-    private fun nextSchedule(nextDelay: Long) {
+    private fun nextSchedule(nextDelay: Long, generation: Long) {
         log.debug {
             "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] - nextDelay:[$nextDelay]."
         }
-        if (!status.isActive) {
+        if (!status.isActive || generation != lifecycleGeneration.get()) {
             /*
              * A contend task can still be in flight when stop() shuts the executor down
              * (JDBC calls are not interruptible); scheduling on from that path would throw
@@ -68,10 +71,15 @@ class JdbcMutexContendService(
             }
             return
         }
-        contendScheduledFuture = executorService!!.schedule({ safeHandleContend() }, nextDelay, TimeUnit.MILLISECONDS)
+        contendScheduledFuture = executorService!!.schedule(
+            { safeHandleContend(generation) },
+            nextDelay,
+            TimeUnit.MILLISECONDS
+        )
     }
 
     override fun stopContend() {
+        lifecycleGeneration.incrementAndGet()
         contendScheduledFuture?.cancel(true)
         executorService?.shutdown()
         notifyOwner(MutexOwner.NONE)
@@ -79,17 +87,23 @@ class JdbcMutexContendService(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun safeHandleContend() {
+    private fun safeHandleContend(generation: Long) {
         try {
             val mutexOwner = contend()
+            if (!status.isActive || generation != lifecycleGeneration.get()) {
+                if (mutexOwner.isOwner(contenderId)) {
+                    mutexOwnerRepository.release(mutex, contenderId)
+                }
+                return
+            }
             notifyOwner(mutexOwner)
             val nextDelay = contendPeriod.ensureNextDelay(mutexOwner)
-            nextSchedule(nextDelay)
+            nextSchedule(nextDelay, generation)
         } catch (throwable: Throwable) {
             log.error(throwable) {
                 "safeHandleContend - mutex:[$mutex] contenderId:[$contenderId] - failed:[${throwable.message}]."
             }
-            nextSchedule(ttl.toMillis())
+            nextSchedule(ttl.toMillis(), generation)
         }
     }
 

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
@@ -24,6 +24,7 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Unit test for the stop/in-flight-task race. No database required:
@@ -39,10 +40,13 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 class JdbcMutexContendServiceStopTest {
     @Test
-    fun `contend task completing after stop must not attempt to reschedule`() {
+    fun `contend task completing after stop compensates acquisition without rescheduling`() {
         val invoked = CountDownLatch(1)
         val inFlight = CountDownLatch(1)
+        val completed = CountDownLatch(1)
+        val compensatingRelease = CountDownLatch(1)
         val acquireCount = AtomicInteger()
+        val ownerId = AtomicReference("")
         val repository = object : MutexOwnerRepository {
             override fun initMutex(mutex: String) = true
             override fun tryInitMutex(mutex: String) = true
@@ -68,10 +72,18 @@ class JdbcMutexContendServiceStopTest {
                     } catch (_: InterruptedException) {
                     }
                 }
+                ownerId.set(contenderId)
+                completed.countDown()
                 return MutexOwnerEntity(mutex, contenderId, 0, Long.MAX_VALUE, Long.MAX_VALUE)
             }
 
-            override fun release(mutex: String, contenderId: String) = true
+            override fun release(mutex: String, contenderId: String): Boolean {
+                val released = ownerId.compareAndSet(contenderId, "")
+                if (released) {
+                    compensatingRelease.countDown()
+                }
+                return released
+            }
 
             override fun ensureOwner(mutex: String): MutexOwnerEntity {
                 throw NotFoundMutexOwnerException("not expected in this test")
@@ -104,6 +116,7 @@ class JdbcMutexContendServiceStopTest {
         assertThat(recordingExecutor.scheduleAttemptsWhenShutdown.get(), equalTo(0))
 
         inFlight.countDown()
+        assertThat("in-flight acquire should complete", completed.await(2, TimeUnit.SECONDS))
 
         // the in-flight task finishes now: any (buggy) rescheduling attempt lands on the
         // shut-down recording executor within milliseconds
@@ -119,6 +132,12 @@ class JdbcMutexContendServiceStopTest {
             equalTo(0)
         )
         assertThat("no further contention should run after stop", acquireCount.get(), equalTo(1))
+        assertThat(
+            "an acquisition completing after stop must be compensated",
+            compensatingRelease.await(1, TimeUnit.SECONDS),
+            equalTo(true)
+        )
+        assertThat(ownerId.get(), equalTo(""))
     }
 
     private class RecordingScheduledExecutor : ScheduledThreadPoolExecutor(1) {


### PR DESCRIPTION
## What changed

- tag each JDBC contention loop with a lifecycle generation
- invalidate in-flight work before stop cancels and releases
- compensate an acquisition that completes after its lifecycle has stopped
- prevent stale tasks from rescheduling into a restarted service

## Root cause

JDBC calls are not reliably interruptible. `stop()` could release the row while an older acquire was still blocked; that acquire could then complete successfully after stop and leave an orphan owner until the lease expired.

## Validation

- `./gradlew :simba-jdbc:test --tests me.ahoo.simba.jdbc.JdbcMutexContendServiceStopTest --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `./gradlew :simba-jdbc:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1` with MySQL 8.0 Docker
- `git diff --check agent/simba-locker-failure-cleanup..HEAD`

## Dependency

Stacked on #450; merge and retarget in order.
