### PR TITLE
fix(jdbc): revoke owner when renewal fails

### DIFF
--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
@@ -103,6 +103,9 @@ class JdbcMutexContendService(
             log.error(throwable) {
                 "safeHandleContend - mutex:[$mutex] contenderId:[$contenderId] - failed:[${throwable.message}]."
             }
+            if (status.isActive && generation == lifecycleGeneration.get() && isOwner) {
+                notifyOwner(MutexOwner.NONE)
+            }
             nextSchedule(ttl.toMillis(), generation)
         }
     }

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
@@ -140,6 +140,79 @@ class JdbcMutexContendServiceStopTest {
         assertThat(ownerId.get(), equalTo(""))
     }
 
+    @Test
+    fun `renewal failure revokes local ownership by lease deadline`() {
+        val acquired = CountDownLatch(1)
+        val renewalAttempted = CountDownLatch(1)
+        val released = CountDownLatch(1)
+        val attempts = AtomicInteger()
+        val repository = object : MutexOwnerRepository {
+            override fun initMutex(mutex: String) = true
+            override fun tryInitMutex(mutex: String) = true
+
+            override fun getOwner(mutex: String): MutexOwnerEntity {
+                throw NotFoundMutexOwnerException("not expected in this test")
+            }
+
+            override fun acquire(mutex: String, contenderId: String, ttl: Long, transition: Long) = false
+
+            override fun acquireAndGetOwner(
+                mutex: String,
+                contenderId: String,
+                ttl: Long,
+                transition: Long
+            ): MutexOwnerEntity {
+                if (attempts.getAndIncrement() == 0) {
+                    val now = System.currentTimeMillis()
+                    return MutexOwnerEntity(mutex, contenderId, now, now + 50, now + 100).also {
+                        it.currentDbAt = now
+                    }
+                }
+                renewalAttempted.countDown()
+                throw IllegalStateException("database unavailable")
+            }
+
+            override fun release(mutex: String, contenderId: String) = true
+
+            override fun ensureOwner(mutex: String): MutexOwnerEntity {
+                throw NotFoundMutexOwnerException("not expected in this test")
+            }
+        }
+        val contender = object : AbstractMutexContender("lease-expiry") {
+            override fun onAcquired(mutexState: MutexState) {
+                acquired.countDown()
+            }
+
+            override fun onReleased(mutexState: MutexState) {
+                released.countDown()
+            }
+        }
+        val contendService = JdbcMutexContendService(
+            contender,
+            Executor { it.run() },
+            repository,
+            Duration.ZERO,
+            Duration.ofMillis(100),
+            Duration.ofMillis(50)
+        )
+
+        try {
+            contendService.start()
+            assertThat("initial acquisition should succeed", acquired.await(1, TimeUnit.SECONDS))
+            assertThat("renewal should be attempted", renewalAttempted.await(1, TimeUnit.SECONDS))
+            assertThat(
+                "local ownership must expire when renewal cannot complete",
+                released.await(300, TimeUnit.MILLISECONDS),
+                equalTo(true)
+            )
+            assertThat(contendService.isOwner, equalTo(false))
+        } finally {
+            if (contendService.running) {
+                contendService.stop()
+            }
+        }
+    }
+
     private class RecordingScheduledExecutor : ScheduledThreadPoolExecutor(1) {
         val scheduleAttemptsWhenShutdown = AtomicInteger()
 

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceTest.kt
@@ -13,11 +13,19 @@
 package me.ahoo.simba.jdbc
 
 import com.zaxxer.hikari.HikariDataSource
+import me.ahoo.simba.core.AbstractMutexContender
 import me.ahoo.simba.core.MutexContendServiceFactory
+import me.ahoo.simba.core.MutexState
 import me.ahoo.simba.test.MutexContendServiceSpec
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * @author ahoo wang
@@ -47,5 +55,96 @@ internal class JdbcMutexContendServiceTest : MutexContendServiceSpec() {
         jdbcMutexOwnerRepository.tryInitMutex(GUARD_MUTEX)
         jdbcMutexOwnerRepository.tryInitMutex(MULTI_CONTEND_MUTEX)
         jdbcMutexOwnerRepository.tryInitMutex(SCHEDULE_MUTEX)
+    }
+
+    @Test
+    fun `old owner is revoked before another contender acquires after renewal partition`() {
+        val mutex = "lease-partition-${System.nanoTime()}"
+        jdbcMutexOwnerRepository.ensureOwner(mutex)
+        val ownerAAcquired = CountDownLatch(1)
+        val ownerAReleased = CountDownLatch(1)
+        val ownerBAcquired = CountDownLatch(1)
+        val attempts = AtomicInteger()
+        val partitionedRepository = object : MutexOwnerRepository {
+            override fun initMutex(mutex: String) = jdbcMutexOwnerRepository.initMutex(mutex)
+            override fun tryInitMutex(mutex: String) = jdbcMutexOwnerRepository.tryInitMutex(mutex)
+            override fun getOwner(mutex: String) = jdbcMutexOwnerRepository.getOwner(mutex)
+
+            override fun acquire(mutex: String, contenderId: String, ttl: Long, transition: Long): Boolean {
+                return jdbcMutexOwnerRepository.acquire(mutex, contenderId, ttl, transition)
+            }
+
+            override fun acquireAndGetOwner(
+                mutex: String,
+                contenderId: String,
+                ttl: Long,
+                transition: Long
+            ): MutexOwnerEntity {
+                if (attempts.getAndIncrement() == 0) {
+                    return jdbcMutexOwnerRepository.acquireAndGetOwner(mutex, contenderId, ttl, transition)
+                }
+                throw IllegalStateException("owner A cannot renew")
+            }
+
+            override fun release(mutex: String, contenderId: String): Boolean {
+                return jdbcMutexOwnerRepository.release(mutex, contenderId)
+            }
+
+            override fun ensureOwner(mutex: String) = jdbcMutexOwnerRepository.ensureOwner(mutex)
+        }
+        val ownerA = object : AbstractMutexContender(mutex, "owner-a") {
+            override fun onAcquired(mutexState: MutexState) {
+                ownerAAcquired.countDown()
+            }
+
+            override fun onReleased(mutexState: MutexState) {
+                ownerAReleased.countDown()
+            }
+        }
+        val ownerB = object : AbstractMutexContender(mutex, "owner-b") {
+            override fun onAcquired(mutexState: MutexState) {
+                ownerBAcquired.countDown()
+            }
+        }
+        val ownerAService = JdbcMutexContendService(
+            ownerA,
+            Runnable::run,
+            partitionedRepository,
+            Duration.ZERO,
+            Duration.ofMillis(200),
+            Duration.ofMillis(100)
+        )
+        val ownerBService = JdbcMutexContendService(
+            ownerB,
+            Runnable::run,
+            jdbcMutexOwnerRepository,
+            Duration.ZERO,
+            Duration.ofMillis(200),
+            Duration.ofMillis(100)
+        )
+
+        try {
+            ownerAService.start()
+            assertThat("owner A should acquire first", ownerAAcquired.await(2, TimeUnit.SECONDS))
+            ownerBService.start()
+            assertThat("owner B should acquire after A's lease expires", ownerBAcquired.await(5, TimeUnit.SECONDS))
+
+            assertThat(
+                "owner A must be revoked before owner B starts working",
+                ownerAReleased.await(1, TimeUnit.SECONDS),
+                equalTo(true)
+            )
+            assertThat(ownerAService.isOwner, equalTo(false))
+            assertThat(ownerBService.isOwner, equalTo(true))
+        } finally {
+            if (ownerBService.running) {
+                ownerBService.stop()
+            }
+            if (ownerAService.running) {
+                ownerAService.stop()
+            }
+            jdbcMutexOwnerRepository.release(mutex, "owner-a")
+            jdbcMutexOwnerRepository.release(mutex, "owner-b")
+        }
     }
 }


### PR DESCRIPTION
## What changed

- revoke local JDBC ownership when an active renewal attempt fails
- keep non-owner acquisition failures on the existing retry path
- add a deterministic short-lease regression test
- add a MySQL integration test proving the old owner stops before a successor works

## Root cause

The JDBC failure path logged and retried without changing local owner state. After the database lease expired, another process could acquire the row while the partitioned process continued running owner work indefinitely.

## Validation

- deterministic renewal-failure test in `JdbcMutexContendServiceStopTest`
- real two-contender MySQL 8.0 Docker test in `JdbcMutexContendServiceTest`
- `./gradlew :simba-jdbc:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `git diff --check agent/jdbc-stop-acquire-compensation..HEAD`

## Dependency

Stacked on #451; merge and retarget in order.
