### PR TITLE
fix(redis): keep a single contention schedule

### DIFF
--- a/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
+++ b/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
@@ -32,6 +32,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Spring Redis Mutex Contend Service.
@@ -78,6 +79,9 @@ class SpringRedisMutexContendService(
     private val listenTopics: List<ChannelTopic> = listOf(ChannelTopic(mutexChannel), ChannelTopic(contenderChannel))
     private val contendPeriod: ContendPeriod = ContendPeriod(contenderId)
     private val mutexMessageListener: MutexMessageListener = MutexMessageListener()
+    private val lifecycleGeneration = AtomicLong()
+    private val scheduleLock = Any()
+    private var scheduleToken = 0L
 
     /**
      * Written by the scheduling executor thread and cancelled by the stopping thread;
@@ -99,8 +103,9 @@ class SpringRedisMutexContendService(
         log.info {
             "startContend - mutex:[$mutex] contenderId:[$contenderId]."
         }
+        val generation = lifecycleGeneration.incrementAndGet()
         startSubscribe()
-        nextSchedule(0)
+        nextSchedule(0, generation)
     }
 
     /**
@@ -110,67 +115,90 @@ class SpringRedisMutexContendService(
         listenerContainer.addMessageListener(mutexMessageListener, listenTopics)
     }
 
-    private fun nextSchedule(nextDelay: Long) {
+    private fun nextSchedule(nextDelay: Long, generation: Long) {
         log.debug {
             "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] status:[$status] delay:[${nextDelay}ms]."
         }
 
-        if (!status.isActive) {
-            log.warn {
-                "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] is not active[$status]."
+        synchronized(scheduleLock) {
+            if (!status.isActive || generation != lifecycleGeneration.get()) {
+                log.warn {
+                    "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] is not active[$status]."
+                }
+                return
             }
-            return
+            val token = ++scheduleToken
+            scheduleFuture?.cancel(true)
+            scheduleFuture = scheduledExecutorService.schedule<MutexOwner>({
+                runScheduled(generation, token)
+            }, nextDelay, TimeUnit.MILLISECONDS)
         }
-        scheduleFuture = scheduledExecutorService.schedule<MutexOwner>({
-            safeContend()
-        }, nextDelay, TimeUnit.MILLISECONDS)
+    }
+
+    private fun runScheduled(generation: Long, token: Long): MutexOwner {
+        synchronized(scheduleLock) {
+            if (!status.isActive ||
+                generation != lifecycleGeneration.get() ||
+                token != scheduleToken
+            ) {
+                return MutexOwner.NONE
+            }
+            scheduleFuture = null
+        }
+        return safeContend(generation)
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun safeContend(): MutexOwner {
+    private fun safeContend(generation: Long): MutexOwner {
         return try {
             if (isOwner) {
-                guard()
+                guard(generation)
             } else {
-                acquire()
+                acquire(generation)
             }
         } catch (throwable: Throwable) {
             log.error(throwable) {
                 "safeContend - mutex:[$mutex] contenderId:[$contenderId] error."
             }
-            if (isOwner) {
+            if (status.isActive && generation == lifecycleGeneration.get() && isOwner) {
                 notifyOwner(MutexOwner.NONE)
             }
-            nextSchedule(ttl.toMillis())
+            nextSchedule(ttl.toMillis(), generation)
             MutexOwner.NONE
         }
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun notifyOwnerAndScheduleNext(resultStr: String): MutexOwner {
+    private fun notifyOwnerAndScheduleNext(resultStr: String, generation: Long): MutexOwner {
         return try {
             val result: AcquireResult = AcquireResult.of(resultStr)
             val mutexOwner = newMutexOwner(result)
+            if (!status.isActive || generation != lifecycleGeneration.get()) {
+                if (mutexOwner.isOwner(contenderId)) {
+                    releaseRemote()
+                }
+                return MutexOwner.NONE
+            }
             notifyOwner(mutexOwner)
             val nextDelay = contendPeriod.ensureNextDelay(mutexOwner)
-            nextSchedule(nextDelay)
+            nextSchedule(nextDelay, generation)
             mutexOwner
         } catch (throwable: Throwable) {
             log.error(throwable) { "notifyOwnerAndScheduleNext - mutex:[$mutex] contenderId:[$contenderId] error." }
-            nextSchedule(ttl.toMillis())
+            nextSchedule(ttl.toMillis(), generation)
             MutexOwner.NONE
         }
     }
 
-    private fun guard(): MutexOwner {
+    private fun guard(generation: Long): MutexOwner {
         val message = redisTemplate.execute(SCRIPT_GUARD, keys, contenderId, ttl.toMillis().toString())
         log.debug {
             "guard - mutex:[$mutex] contenderId:[$contenderId] - message:[$message]."
         }
-        return notifyOwnerAndScheduleNext(message)
+        return notifyOwnerAndScheduleNext(message, generation)
     }
 
-    private fun acquire(): MutexOwner {
+    private fun acquire(generation: Long): MutexOwner {
         val message = redisTemplate.execute(
             SCRIPT_ACQUIRE,
             keys,
@@ -180,7 +208,7 @@ class SpringRedisMutexContendService(
         log.debug {
             "acquire - mutex:[$mutex] contenderId:[$contenderId] - message:[$message]."
         }
-        return notifyOwnerAndScheduleNext(message)
+        return notifyOwnerAndScheduleNext(message, generation)
     }
 
     private fun newMutexOwner(result: AcquireResult): MutexOwner {
@@ -206,6 +234,7 @@ class SpringRedisMutexContendService(
         log.info {
             "stopContend - mutex:[$mutex] contenderId:[$contenderId]."
         }
+        lifecycleGeneration.incrementAndGet()
         stopSubscribe()
         disposeSchedule()
         release()
@@ -219,15 +248,20 @@ class SpringRedisMutexContendService(
     }
 
     private fun disposeSchedule() {
-        scheduleFuture?.let {
-            it.cancel(true)
+        synchronized(scheduleLock) {
+            scheduleToken++
+            scheduleFuture?.cancel(true)
             scheduleFuture = null
         }
     }
 
+    private fun releaseRemote(): Boolean {
+        return redisTemplate.execute(SCRIPT_RELEASE, keys, contenderId)
+    }
+
     @Suppress("TooGenericExceptionCaught")
     private fun release() {
-        val succeed = redisTemplate.execute(SCRIPT_RELEASE, keys, contenderId)
+        val succeed = releaseRemote()
         log.debug {
             "release - mutex:[$mutex] - contenderId:[$contenderId] - succeed:[$succeed]"
         }
@@ -257,7 +291,7 @@ class SpringRedisMutexContendService(
             when (ownerEvent.event) {
                 OwnerEvent.EVENT_RELEASED -> {
                     notifyOwner(MutexOwner.NONE)
-                    acquire()
+                    nextSchedule(0, lifecycleGeneration.get())
                 }
 
                 OwnerEvent.EVENT_ACQUIRED -> {

--- a/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceSchedulingTest.kt
+++ b/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceSchedulingTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.spring.redis
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.simba.core.AbstractMutexContender
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.DefaultMessage
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import java.time.Duration
+import java.util.concurrent.Callable
+import java.util.concurrent.Delayed
+import java.util.concurrent.FutureTask
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class SpringRedisMutexContendServiceSchedulingTest {
+    @Test
+    fun `released event replaces the pending retry`() {
+        val contender = object : AbstractMutexContender("released", "released-owner") {}
+        val redisTemplate = stringRedisTemplateReturning("other@@15000")
+        val scheduler = ManualScheduledExecutor()
+        val service = newService(contender, redisTemplate, scheduler)
+
+        service.start()
+        scheduler.run(0)
+        service.MutexMessageListener().onMessage(
+            DefaultMessage(
+                "simba:{released}:${contender.contenderId}".toByteArray(),
+                "released@@other".toByteArray()
+            ),
+            null
+        )
+
+        assertThat(scheduler.pendingTaskCount, equalTo(1))
+        scheduler.shutdownNow()
+    }
+
+    @Test
+    fun `stop prevents a superseded future from acquiring`() {
+        val contender = object : AbstractMutexContender("stopped", "stopped-owner") {}
+        val acquireCalls = AtomicInteger()
+        val redisTemplate = stringRedisTemplateReturning("other@@15000", acquireCalls)
+        every {
+            redisTemplate.execute(
+                match<RedisScript<Boolean>> { it.resultType == Boolean::class.java },
+                any<List<String>>(),
+                *anyVararg()
+            )
+        } returns true
+        val scheduler = ManualScheduledExecutor()
+        val service = newService(contender, redisTemplate, scheduler)
+
+        service.start()
+        scheduler.run(0)
+        service.MutexMessageListener().onMessage(
+            DefaultMessage(
+                "simba:{stopped}:${contender.contenderId}".toByteArray(),
+                "released@@other".toByteArray()
+            ),
+            null
+        )
+        val callsBeforeStop = acquireCalls.get()
+
+        service.stop()
+        scheduler.runActive()
+
+        assertThat(acquireCalls.get(), equalTo(callsBeforeStop))
+        scheduler.shutdownNow()
+    }
+
+    private fun stringRedisTemplateReturning(
+        result: String,
+        calls: AtomicInteger = AtomicInteger()
+    ): StringRedisTemplate {
+        return mockk<StringRedisTemplate>(relaxed = true).also { redisTemplate ->
+            every {
+                redisTemplate.execute(
+                    match<RedisScript<String>> { it.resultType == String::class.java },
+                    any<List<String>>(),
+                    *anyVararg()
+                )
+            } answers {
+                calls.incrementAndGet()
+                result
+            }
+        }
+    }
+
+    private fun newService(
+        contender: AbstractMutexContender,
+        redisTemplate: StringRedisTemplate,
+        scheduler: ScheduledThreadPoolExecutor
+    ): SpringRedisMutexContendService {
+        return SpringRedisMutexContendService(
+            contender,
+            Runnable::run,
+            Duration.ofSeconds(5),
+            Duration.ofSeconds(10),
+            redisTemplate,
+            mockk<RedisMessageListenerContainer>(relaxed = true),
+            scheduler
+        )
+    }
+
+    private class ManualScheduledExecutor : ScheduledThreadPoolExecutor(1) {
+        private val tasks = mutableListOf<ManualScheduledFuture<*>>()
+
+        override fun <V : Any?> schedule(
+            callable: Callable<V>,
+            delay: Long,
+            unit: TimeUnit
+        ): ScheduledFuture<V> {
+            return ManualScheduledFuture(callable).also { tasks += it }
+        }
+
+        fun run(index: Int) {
+            tasks[index].run()
+        }
+
+        fun runActive() {
+            tasks.toList().forEach {
+                if (!it.isDone && !it.isCancelled) {
+                    it.run()
+                }
+            }
+        }
+
+        val pendingTaskCount: Int
+            get() = tasks.count { !it.isDone && !it.isCancelled }
+    }
+
+    private class ManualScheduledFuture<V>(callable: Callable<V>) :
+        FutureTask<V>(callable),
+        ScheduledFuture<V> {
+        override fun getDelay(unit: TimeUnit): Long = 0
+        override fun compareTo(other: Delayed): Int = 0
+    }
+}


### PR DESCRIPTION
## What changed

- enforce one pending Redis contention task per service
- route release wakeups through the scheduler instead of synchronous Redis calls
- invalidate queued and in-flight work with lifecycle generations and schedule tokens
- compensate a stale task that acquires after stop

## Root cause

A targeted `released` message performed an immediate acquire while the existing retry remained scheduled. Each path then scheduled its own successor, but the service retained only the newest future. Stop could cancel one chain while older tasks continued and reacquired an orphan lock.

## Validation

- deterministic pending-task and post-stop execution tests in `SpringRedisMutexContendServiceSchedulingTest`
- `./gradlew :simba-spring-redis:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `git diff --check agent/redis-revoke-owner-on-renewal-failure..HEAD`

## Dependency

Stacked on #453; merge and retarget in order.
