### PR TITLE
fix(redis): renew the full lock lease

### DIFF
--- a/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
+++ b/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
@@ -191,7 +191,12 @@ class SpringRedisMutexContendService(
     }
 
     private fun guard(generation: Long): MutexOwner {
-        val message = redisTemplate.execute(SCRIPT_GUARD, keys, contenderId, ttl.toMillis().toString())
+        val message = redisTemplate.execute(
+            SCRIPT_GUARD,
+            keys,
+            contenderId,
+            (ttl.toMillis() + transition.toMillis()).toString()
+        )
         log.debug {
             "guard - mutex:[$mutex] contenderId:[$contenderId] - message:[$message]."
         }

--- a/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceSchedulingTest.kt
+++ b/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceSchedulingTest.kt
@@ -14,6 +14,7 @@ package me.ahoo.simba.spring.redis
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import me.ahoo.simba.core.AbstractMutexContender
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -32,6 +33,35 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 class SpringRedisMutexContendServiceSchedulingTest {
+    @Test
+    fun `guard renews ttl plus transition`() {
+        val contender = object : AbstractMutexContender("guard-lease", "guard-owner") {}
+        val redisTemplate = mockk<StringRedisTemplate>(relaxed = true)
+        every {
+            redisTemplate.execute(
+                match<RedisScript<String>> { it.resultType == String::class.java },
+                any<List<String>>(),
+                *anyVararg()
+            )
+        } returns "${contender.contenderId}@@15000"
+        val scheduler = ManualScheduledExecutor()
+        val service = newService(contender, redisTemplate, scheduler)
+
+        service.start()
+        scheduler.run(0)
+        scheduler.run(1)
+
+        verify(exactly = 2) {
+            redisTemplate.execute(
+                match<RedisScript<String>> { it.resultType == String::class.java },
+                listOf("{guard-lease}"),
+                contender.contenderId,
+                "15000"
+            )
+        }
+        scheduler.shutdownNow()
+    }
+
     @Test
     fun `released event replaces the pending retry`() {
         val contender = object : AbstractMutexContender("released", "released-owner") {}


### PR DESCRIPTION
## What changed

- renew Redis guard leases with `ttl + transition`, matching initial acquisition
- verify acquire and guard both pass the same full lease to Lua

## Root cause

Acquire stored the key for `ttl + transition`, while guard reset it to only `ttl`. Local state still subtracted `transition`, so the next guard delay became `ttl - transition`; configurations where transition was at least TTL produced a zero-delay renewal loop.

## Validation

- guard argument regression in `SpringRedisMutexContendServiceSchedulingTest`
- `./gradlew :simba-spring-redis:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `git diff --check agent/redis-single-schedule-chain..HEAD`

## Dependency

Stacked on #454; merge and retarget in order.
