### PR TITLE
fix(starter): back off JDBC without a data source

### DIFF
--- a/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfiguration.kt
+++ b/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfiguration.kt
@@ -17,8 +17,10 @@ import me.ahoo.simba.jdbc.JdbcMutexContendServiceFactory
 import me.ahoo.simba.jdbc.JdbcMutexOwnerRepository
 import me.ahoo.simba.jdbc.MutexOwnerRepository
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import java.util.concurrent.ForkJoinPool
@@ -38,12 +40,14 @@ import javax.sql.DataSource
 class SimbaJdbcAutoConfiguration(private val jdbcProperties: JdbcProperties) {
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnSingleCandidate(DataSource::class)
     fun mutexOwnerRepository(dataSource: DataSource): MutexOwnerRepository {
         return JdbcMutexOwnerRepository(dataSource)
     }
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnBean(MutexOwnerRepository::class)
     fun jdbcMutexContendServiceFactory(mutexOwnerRepository: MutexOwnerRepository): MutexContendServiceFactory {
         return JdbcMutexContendServiceFactory(
             mutexOwnerRepository = mutexOwnerRepository,

--- a/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfigurationTest.kt
+++ b/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfigurationTest.kt
@@ -78,4 +78,29 @@ internal class SimbaJdbcAutoConfigurationTest {
                     .doesNotHaveBean(MutexContendServiceFactory::class.java)
             }
     }
+
+    @Test
+    fun contextBacksOffWithoutDataSource() {
+        contextRunner
+            .withUserConfiguration(SimbaJdbcAutoConfiguration::class.java)
+            .run {
+                assertThat(it)
+                    .hasNotFailed()
+                    .doesNotHaveBean(MutexOwnerRepository::class.java)
+                    .doesNotHaveBean(MutexContendServiceFactory::class.java)
+            }
+    }
+
+    @Test
+    fun contextLoadsWithCustomRepositoryWithoutDataSource() {
+        contextRunner
+            .withBean(MutexOwnerRepository::class.java, { mockk() })
+            .withUserConfiguration(SimbaJdbcAutoConfiguration::class.java)
+            .run {
+                assertThat(it)
+                    .hasNotFailed()
+                    .hasSingleBean(MutexOwnerRepository::class.java)
+                    .hasSingleBean(MutexContendServiceFactory::class.java)
+            }
+    }
 }


### PR DESCRIPTION
## What changed

- back off the default JDBC repository unless exactly one `DataSource` candidate exists
- create the JDBC contention factory only when a `MutexOwnerRepository` is available
- cover missing-DataSource startup and custom-repository startup

## Root cause

The JDBC auto-configuration only checked that Simba JDBC classes were on the classpath. It still registered a repository bean with a mandatory `DataSource` parameter, so applications without a data source failed startup instead of backing off as documented.

## Validation

- RED/GREEN `ApplicationContextRunner` coverage for missing `DataSource`
- `./gradlew :simba-spring-boot-starter:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `git diff --check agent/redis-guard-full-lease..HEAD`

## Dependency

Stacked on #455; merge and retarget in order.
