### PR TITLE
fix(core): honor owner expiration semantics

### DIFF
--- a/simba-core/src/main/kotlin/me/ahoo/simba/core/MutexRetrievalService.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/core/MutexRetrievalService.kt
@@ -41,7 +41,7 @@ interface MutexRetrievalService : AutoCloseable {
      * @return boolean
      */
     fun hasOwner(): Boolean {
-        return afterOwner !== MutexOwner.NONE
+        return afterOwner.hasOwner()
     }
 
     val running: Boolean

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/AbstractMutexRetrievalServiceTest.kt
@@ -140,7 +140,7 @@ class AbstractMutexRetrievalServiceTest {
         val contender = FakeMutexContender("m", "c1")
         val service = FakeMutexContendService(contender)
         service.start()
-        service.publishOwner(MutexOwner("c1", 0, 100, 200)).join()
+        service.publishOwner(MutexOwner("c1", 0, Long.MAX_VALUE, Long.MAX_VALUE)).join()
         assertThat(service.hasOwner(), equalTo(true))
 
         service.stop()
@@ -211,7 +211,7 @@ class AbstractMutexRetrievalServiceTest {
         val executor = ManualExecutor()
         val service = FakeMutexContendService(contender, executor)
         service.start()
-        val acquisition = service.publishOwner(MutexOwner("c1", 0, 100, 200))
+        val acquisition = service.publishOwner(MutexOwner("c1", 0, Long.MAX_VALUE, Long.MAX_VALUE))
         executor.runAll()
         acquisition.join()
         assertThat(service.hasOwner(), equalTo(true))

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexRetrievalServiceTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexRetrievalServiceTest.kt
@@ -39,19 +39,31 @@ class MutexRetrievalServiceTest {
     }
 
     @Test
-    fun `hasOwner is false when afterOwner is NONE by identity`() {
+    fun `hasOwner is false when afterOwner is NONE`() {
         val service = FakeMutexContendService(FakeMutexContender("m", "c1"))
         // mutexState defaults to MutexState.NONE -> afterOwner is MutexOwner.NONE
         assertThat(service.hasOwner(), equalTo(false))
     }
 
     @Test
-    fun `hasOwner is true when afterOwner is a real owner`() {
+    fun `hasOwner is false when an equivalent owner has expired`() {
         val contender = FakeMutexContender("m", "c1")
         val service = FakeMutexContendService(contender)
         service.start()
 
-        service.publishOwner(MutexOwner("c1", 0, 100, 200)).join()
+        service.publishOwner(FixedClockOwner("", 0, 0, 1)).join()
+
+        assertThat(service.hasOwner(), equalTo(false))
+        service.stop()
+    }
+
+    @Test
+    fun `hasOwner is true when afterOwner is active`() {
+        val contender = FakeMutexContender("m", "c1")
+        val service = FakeMutexContendService(contender)
+        service.start()
+
+        service.publishOwner(FixedClockOwner("c1", 100, 200, 150)).join()
 
         assertThat(service.hasOwner(), equalTo(true))
         service.stop()


### PR DESCRIPTION
## What changed

- derive service `hasOwner()` from `MutexOwner` transition-time semantics
- treat equivalent/expired no-owner values consistently with `MutexOwner.hasOwner()`
- update owner fixtures so active-owner tests use active timestamps

## Root cause

`MutexRetrievalService.hasOwner()` used object identity against the `MutexOwner.NONE` singleton. Any equivalent empty owner or expired owner object was reported as active even though the owner model itself reported no owner.

## Validation

- RED/GREEN expired-owner regression in `MutexRetrievalServiceTest`
- `./gradlew :simba-core:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `git diff --check agent/jdbc-autoconfiguration-backoff..HEAD`

## Dependency

Stacked on #456; merge and retarget in order.
