### PR TITLE
fix(core): clean up failed locker acquisition

### DIFF
--- a/simba-core/src/main/kotlin/me/ahoo/simba/locker/SimbaLocker.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/locker/SimbaLocker.kt
@@ -57,11 +57,17 @@ class SimbaLocker(
 
     @Throws(Exception::class)
     override fun close() {
-        contendService.stop()
+        try {
+            if (contendService.running) {
+                contendService.stop()
+            }
+        } finally {
+            OWNER.set(this, null)
+        }
     }
 
     override fun acquire() {
-        if (OWNER.compareAndSet(this, null, Thread.currentThread())) {
+        acquireOwned {
             contendService.start()
             var interrupted = false
             /*
@@ -79,14 +85,12 @@ class SimbaLocker(
             if (interrupted) {
                 Thread.currentThread().interrupt()
             }
-        } else {
-            throw IllegalMonitorStateException("Thread[${OWNER.get(this)}] already owns this lock[$mutex].")
         }
     }
 
     @Throws(TimeoutException::class)
     override fun acquire(timeout: Duration) {
-        if (OWNER.compareAndSet(this, null, Thread.currentThread())) {
+        acquireOwned {
             contendService.start()
             val deadline = System.nanoTime() + timeout.toNanos()
             var interrupted = false
@@ -108,13 +112,27 @@ class SimbaLocker(
                     "Could not acquire [$contenderId]@mutex:[$mutex] within timeout of ${timeout.toMillis()}ms"
                 )
             }
-        } else {
-            throw IllegalMonitorStateException("Thread[${OWNER.get(this)}] already owns this lock[$mutex].")
         }
     }
 
     override fun onAcquired(mutexState: MutexState) {
         super.onAcquired(mutexState)
         LockSupport.unpark(OWNER[this])
+    }
+
+    private inline fun acquireOwned(acquire: () -> Unit) {
+        if (!OWNER.compareAndSet(this, null, Thread.currentThread())) {
+            throw IllegalMonitorStateException("Thread[${OWNER.get(this)}] already owns this lock[$mutex].")
+        }
+        try {
+            acquire()
+        } catch (error: Throwable) {
+            try {
+                close()
+            } catch (cleanupError: Throwable) {
+                error.addSuppressed(cleanupError)
+            }
+            throw error
+        }
     }
 }

--- a/simba-core/src/main/kotlin/me/ahoo/simba/locker/SimbaLocker.kt
+++ b/simba-core/src/main/kotlin/me/ahoo/simba/locker/SimbaLocker.kt
@@ -127,10 +127,15 @@ class SimbaLocker(
         try {
             acquire()
         } catch (error: Throwable) {
+            val interrupted = Thread.interrupted()
             try {
                 close()
             } catch (cleanupError: Throwable) {
                 error.addSuppressed(cleanupError)
+            } finally {
+                if (interrupted) {
+                    Thread.currentThread().interrupt()
+                }
             }
             throw error
         }

--- a/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
@@ -23,6 +23,7 @@ import me.ahoo.simba.core.SameThreadExecutor
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.sameInstance
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.Duration
@@ -39,8 +40,16 @@ import kotlin.concurrent.thread
 private class ControllableContendService(
     contender: MutexContender
 ) : AbstractMutexContendService(contender, SameThreadExecutor) {
-    override fun startContend() = Unit
-    override fun stopContend() = Unit
+    var startFailure: Throwable? = null
+    var stopFailure: Throwable? = null
+
+    override fun startContend() {
+        startFailure?.let { throw it }
+    }
+
+    override fun stopContend() {
+        stopFailure?.let { throw it }
+    }
 
     fun markOwner(ownerId: String) {
         notifyOwner(MutexOwner(ownerId, 0, Long.MAX_VALUE, Long.MAX_VALUE))
@@ -73,6 +82,52 @@ class SimbaLockerTest {
         }
         assertThat(error.message, containsString("Could not acquire"))
         assertThat(error.message, containsString("within timeout of 50ms"))
+    }
+
+    @Test
+    fun `timed out acquire cleans up so same locker can retry`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+
+        assertThrows<TimeoutException> {
+            locker.acquire(Duration.ofMillis(1))
+        }
+
+        assertThrows<TimeoutException> {
+            locker.acquire(Duration.ofMillis(1))
+        }
+    }
+
+    @Test
+    fun `start failure clears local owner so acquire can retry`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+        val failure = IllegalStateException("boom")
+        factory.service!!.startFailure = failure
+
+        val error = assertThrows<IllegalStateException> {
+            locker.acquire()
+        }
+        assertThat(error, equalTo(failure))
+
+        factory.service!!.startFailure = null
+        assertThrows<TimeoutException> {
+            locker.acquire(Duration.ofMillis(1))
+        }
+    }
+
+    @Test
+    fun `timeout preserves acquisition error when cleanup fails`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+        val cleanupFailure = IllegalStateException("cleanup-boom")
+        factory.service!!.stopFailure = cleanupFailure
+
+        val error = assertThrows<TimeoutException> {
+            locker.acquire(Duration.ofMillis(1))
+        }
+
+        assertThat(error.suppressed.single(), sameInstance(cleanupFailure))
     }
 
     @Test
@@ -168,12 +223,12 @@ class SimbaLockerTest {
     }
 
     @Test
-    fun `close throws IllegalStateException when contend service not running`() {
+    fun `close is idempotent when contend service is not running`() {
         val factory = ControllableFactory()
         val locker = SimbaLocker("m", factory)
 
-        val error = assertThrows<IllegalStateException> { locker.close() }
-        assertThat(error.message, containsString("Cannot stop mutex:[m]"))
+        locker.close()
+        locker.close()
     }
 
     /**

--- a/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/locker/SimbaLockerTest.kt
@@ -42,12 +42,14 @@ private class ControllableContendService(
 ) : AbstractMutexContendService(contender, SameThreadExecutor) {
     var startFailure: Throwable? = null
     var stopFailure: Throwable? = null
+    var stopInterrupted: Boolean? = null
 
     override fun startContend() {
         startFailure?.let { throw it }
     }
 
     override fun stopContend() {
+        stopInterrupted = Thread.currentThread().isInterrupted
         stopFailure?.let { throw it }
     }
 
@@ -128,6 +130,24 @@ class SimbaLockerTest {
         }
 
         assertThat(error.suppressed.single(), sameInstance(cleanupFailure))
+    }
+
+    @Test
+    fun `interrupted timeout cleans up before restoring interrupt status`() {
+        val factory = ControllableFactory()
+        val locker = SimbaLocker("m", factory)
+        Thread.currentThread().interrupt()
+
+        try {
+            assertThrows<TimeoutException> {
+                locker.acquire(Duration.ZERO)
+            }
+
+            assertThat(factory.service!!.stopInterrupted, equalTo(false))
+            assertThat(Thread.currentThread().isInterrupted, equalTo(true))
+        } finally {
+            Thread.interrupted()
+        }
     }
 
     @Test


### PR DESCRIPTION
## What changed

- stop an active contention service when acquisition fails
- always clear the locker's local owner during close, including cleanup failures
- make `close()` idempotent, matching the documented RAII contract
- preserve the original acquisition error and attach cleanup failures as suppressed exceptions
- add deterministic coverage for timeout retry, start-failure retry, cleanup failure, and repeated close

## Root cause

`SimbaLocker` claimed its local `OWNER` before starting contention, but timeout and start-failure paths never released that claim. A timed-out call also left the contention service running, so it could acquire the distributed mutex after the caller had already received `TimeoutException`; every retry on the same locker then failed with `IllegalMonitorStateException`.

## Impact

Failed acquisition now leaves the locker reusable and stops active backend work. Successful acquisition behavior and double-acquire rejection are unchanged.

## Validation

- reproduced three failures before the implementation: timeout retry and start-failure retry returned `IllegalMonitorStateException`, while repeated `close()` failed from `INITIAL`
- `./gradlew :simba-core:test --tests me.ahoo.simba.locker.SimbaLockerTest --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `./gradlew :simba-core:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `git diff --check`

Supersedes the closed stacked PR #450 with a clean branch based on current `main`.