### PR TITLE
fix(jdbc): compensate post-stop acquisition

### DIFF
--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
@@ -43,53 +43,88 @@ class JdbcMutexContendService(
 
     private var executorService: ScheduledThreadPoolExecutor? = null
     private val contendPeriod: ContendPeriod = ContendPeriod(contenderId)
+    private val lifecycleLock = Any()
+    private var lifecycleGeneration = 0L
+    private var activeGeneration: Long? = null
 
     @Volatile
     private var contendScheduledFuture: ScheduledFuture<*>? = null
 
     override fun startContend() {
-        executorService =
-            ScheduledThreadPoolExecutor(1, defaultFactory("JdbcSimba_${mutex}_$contenderId"))
-        nextSchedule(initialDelay.toMillis())
+        synchronized(lifecycleLock) {
+            val generation = ++lifecycleGeneration
+            activeGeneration = generation
+            executorService =
+                ScheduledThreadPoolExecutor(1, defaultFactory("JdbcSimba_${mutex}_$contenderId"))
+            nextSchedule(initialDelay.toMillis(), generation)
+        }
     }
 
-    private fun nextSchedule(nextDelay: Long) {
-        log.debug {
-            "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] - nextDelay:[$nextDelay]."
-        }
-        if (!status.isActive) {
-            /*
-             * A contend task can still be in flight when stop() shuts the executor down
-             * (JDBC calls are not interruptible); scheduling on from that path would throw
-             * RejectedExecutionException that nobody observes.
-             */
-            log.warn {
-                "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] is not active[$status]."
+    private fun nextSchedule(nextDelay: Long, generation: Long) {
+        synchronized(lifecycleLock) {
+            log.debug {
+                "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] - nextDelay:[$nextDelay]."
             }
-            return
+            if (!status.isActive || generation != activeGeneration) {
+                /*
+                 * A contend task can still be in flight when stop() shuts the executor down
+                 * (JDBC calls are not interruptible); scheduling on from that path would throw
+                 * RejectedExecutionException that nobody observes.
+                 */
+                log.warn {
+                    "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] is not active[$status]."
+                }
+                return
+            }
+            contendScheduledFuture =
+                executorService!!.schedule({ safeHandleContend(generation) }, nextDelay, TimeUnit.MILLISECONDS)
         }
-        contendScheduledFuture = executorService!!.schedule({ safeHandleContend() }, nextDelay, TimeUnit.MILLISECONDS)
     }
 
     override fun stopContend() {
-        contendScheduledFuture?.cancel(true)
-        executorService?.shutdown()
-        notifyOwner(MutexOwner.NONE)
-        mutexOwnerRepository.release(mutex, contenderId)
+        synchronized(lifecycleLock) {
+            activeGeneration = null
+            contendScheduledFuture?.cancel(true)
+            executorService?.shutdown()
+            notifyOwner(MutexOwner.NONE)
+            mutexOwnerRepository.release(mutex, contenderId)
+        }
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun safeHandleContend() {
+    private fun safeHandleContend(generation: Long) {
         try {
             val mutexOwner = contend()
+            if (!ensureActiveLifecycle(generation, mutexOwner)) {
+                return
+            }
             notifyOwner(mutexOwner)
             val nextDelay = contendPeriod.ensureNextDelay(mutexOwner)
-            nextSchedule(nextDelay)
+            nextSchedule(nextDelay, generation)
         } catch (throwable: Throwable) {
             log.error(throwable) {
                 "safeHandleContend - mutex:[$mutex] contenderId:[$contenderId] - failed:[${throwable.message}]."
             }
-            nextSchedule(ttl.toMillis())
+            nextSchedule(ttl.toMillis(), generation)
+        }
+    }
+
+    private fun ensureActiveLifecycle(generation: Long, mutexOwner: MutexOwner): Boolean {
+        return synchronized(lifecycleLock) {
+            val currentGeneration = activeGeneration
+            if (status.isActive && generation == currentGeneration) {
+                return@synchronized true
+            }
+            /*
+             * A restarted lifecycle reuses contenderId and adopts a late acquisition;
+             * releasing it here would also release the restarted lifecycle's lease.
+             */
+            if (mutexOwner.isOwner(contenderId) &&
+                (currentGeneration == null || generation == currentGeneration)
+            ) {
+                mutexOwnerRepository.release(mutex, contenderId)
+            }
+            false
         }
     }
 

--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
@@ -50,13 +50,20 @@ class JdbcMutexContendService(
     @Volatile
     private var contendScheduledFuture: ScheduledFuture<*>? = null
 
+    @Suppress("TooGenericExceptionCaught")
     override fun startContend() {
         synchronized(lifecycleLock) {
+            val executor = ScheduledThreadPoolExecutor(1, defaultFactory("JdbcSimba_${mutex}_$contenderId"))
             val generation = ++lifecycleGeneration
             activeGeneration = generation
-            executorService =
-                ScheduledThreadPoolExecutor(1, defaultFactory("JdbcSimba_${mutex}_$contenderId"))
-            nextSchedule(initialDelay.toMillis(), generation)
+            executorService = executor
+            try {
+                nextSchedule(initialDelay.toMillis(), generation)
+            } catch (error: Throwable) {
+                activeGeneration = null
+                executor.shutdown()
+                throw error
+            }
         }
     }
 

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
@@ -24,6 +24,7 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Unit test for the stop/in-flight-task race. No database required:
@@ -39,44 +40,8 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 class JdbcMutexContendServiceStopTest {
     @Test
-    fun `contend task completing after stop must not attempt to reschedule`() {
-        val invoked = CountDownLatch(1)
-        val inFlight = CountDownLatch(1)
-        val acquireCount = AtomicInteger()
-        val repository = object : MutexOwnerRepository {
-            override fun initMutex(mutex: String) = true
-            override fun tryInitMutex(mutex: String) = true
-
-            override fun getOwner(mutex: String): MutexOwnerEntity {
-                throw NotFoundMutexOwnerException("not expected in this test")
-            }
-
-            override fun acquire(mutex: String, contenderId: String, ttl: Long, transition: Long) = false
-
-            override fun acquireAndGetOwner(
-                mutex: String,
-                contenderId: String,
-                ttl: Long,
-                transition: Long
-            ): MutexOwnerEntity {
-                acquireCount.incrementAndGet()
-                invoked.countDown()
-                // interrupt-insensitive wait, like a JDBC call in flight
-                while (inFlight.count > 0) {
-                    try {
-                        inFlight.await()
-                    } catch (_: InterruptedException) {
-                    }
-                }
-                return MutexOwnerEntity(mutex, contenderId, 0, Long.MAX_VALUE, Long.MAX_VALUE)
-            }
-
-            override fun release(mutex: String, contenderId: String) = true
-
-            override fun ensureOwner(mutex: String): MutexOwnerEntity {
-                throw NotFoundMutexOwnerException("not expected in this test")
-            }
-        }
+    fun `contend task completing after stop compensates acquisition without rescheduling`() {
+        val repository = BlockingMutexOwnerRepository()
         val contender = object : AbstractMutexContender("m") {
             override fun onAcquired(mutexState: MutexState) = Unit
             override fun onReleased(mutexState: MutexState) = Unit
@@ -97,13 +62,14 @@ class JdbcMutexContendServiceStopTest {
         executorField.isAccessible = true
         executorField.set(contendService, recordingExecutor)
 
-        assertThat("contend task should reach the repository", invoked.await(5, TimeUnit.SECONDS))
+        assertThat("contend task should reach the repository", repository.firstInvoked.await(5, TimeUnit.SECONDS))
 
         contendService.stop()
         // stop shut the recording executor down; the in-flight task is still blocked
         assertThat(recordingExecutor.scheduleAttemptsWhenShutdown.get(), equalTo(0))
 
-        inFlight.countDown()
+        repository.unblockFirst.countDown()
+        assertThat("in-flight acquire should complete", repository.firstCompleted.await(2, TimeUnit.SECONDS))
 
         // the in-flight task finishes now: any (buggy) rescheduling attempt lands on the
         // shut-down recording executor within milliseconds
@@ -118,7 +84,109 @@ class JdbcMutexContendServiceStopTest {
             recordingExecutor.scheduleAttemptsWhenShutdown.get(),
             equalTo(0)
         )
-        assertThat("no further contention should run after stop", acquireCount.get(), equalTo(1))
+        assertThat("no further contention should run after stop", repository.acquireCount.get(), equalTo(1))
+        assertThat(
+            "an acquisition completing after stop must be compensated",
+            repository.compensatingRelease.await(1, TimeUnit.SECONDS),
+            equalTo(true)
+        )
+        assertThat(repository.ownerId.get(), equalTo(""))
+    }
+
+    @Test
+    fun `stale acquisition does not release restarted lifecycle ownership`() {
+        val repository = BlockingMutexOwnerRepository()
+        val contender = object : AbstractMutexContender("m") {
+            override fun onAcquired(mutexState: MutexState) = Unit
+            override fun onReleased(mutexState: MutexState) = Unit
+        }
+        val contendService = JdbcMutexContendService(
+            contender,
+            Executor { it.run() },
+            repository,
+            Duration.ZERO,
+            Duration.ofSeconds(10),
+            Duration.ofSeconds(6)
+        )
+
+        contendService.start()
+        assertThat("first acquire should be in flight", repository.firstInvoked.await(2, TimeUnit.SECONDS))
+        val oldExecutor = executorOf(contendService)
+
+        contendService.stop()
+        contendService.start()
+        assertThat("restarted lifecycle should acquire", repository.secondCompleted.await(2, TimeUnit.SECONDS))
+
+        repository.unblockFirst.countDown()
+        assertThat("stale task should finish", oldExecutor.awaitTermination(2, TimeUnit.SECONDS))
+
+        assertThat(repository.releaseAttempts.get(), equalTo(1))
+        assertThat(repository.ownerId.get(), equalTo(contender.contenderId))
+        contendService.stop()
+    }
+
+    private fun executorOf(contendService: JdbcMutexContendService): ScheduledThreadPoolExecutor {
+        val executorField = JdbcMutexContendService::class.java.getDeclaredField("executorService")
+        executorField.isAccessible = true
+        return executorField.get(contendService) as ScheduledThreadPoolExecutor
+    }
+
+    private class BlockingMutexOwnerRepository : MutexOwnerRepository {
+        val firstInvoked = CountDownLatch(1)
+        val unblockFirst = CountDownLatch(1)
+        val firstCompleted = CountDownLatch(1)
+        val secondCompleted = CountDownLatch(1)
+        val compensatingRelease = CountDownLatch(1)
+        val acquireCount = AtomicInteger()
+        val releaseAttempts = AtomicInteger()
+        val ownerId = AtomicReference("")
+
+        override fun initMutex(mutex: String) = true
+        override fun tryInitMutex(mutex: String) = true
+
+        override fun getOwner(mutex: String): MutexOwnerEntity {
+            throw NotFoundMutexOwnerException("not expected in this test")
+        }
+
+        override fun acquire(mutex: String, contenderId: String, ttl: Long, transition: Long) = false
+
+        override fun acquireAndGetOwner(
+            mutex: String,
+            contenderId: String,
+            ttl: Long,
+            transition: Long
+        ): MutexOwnerEntity {
+            val attempt = acquireCount.incrementAndGet()
+            if (attempt == 1) {
+                firstInvoked.countDown()
+                while (unblockFirst.count > 0) {
+                    try {
+                        unblockFirst.await()
+                    } catch (_: InterruptedException) {
+                    }
+                }
+            }
+            ownerId.set(contenderId)
+            if (attempt == 1) {
+                firstCompleted.countDown()
+            } else if (attempt == 2) {
+                secondCompleted.countDown()
+            }
+            return MutexOwnerEntity(mutex, contenderId, 0, Long.MAX_VALUE, Long.MAX_VALUE)
+        }
+
+        override fun release(mutex: String, contenderId: String): Boolean {
+            releaseAttempts.incrementAndGet()
+            val released = ownerId.compareAndSet(contenderId, "")
+            if (released) {
+                compensatingRelease.countDown()
+            }
+            return released
+        }
+
+        override fun ensureOwner(mutex: String): MutexOwnerEntity {
+            throw NotFoundMutexOwnerException("not expected in this test")
+        }
     }
 
     private class RecordingScheduledExecutor : ScheduledThreadPoolExecutor(1) {

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
@@ -17,6 +17,7 @@ import me.ahoo.simba.core.MutexState
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
@@ -125,10 +126,49 @@ class JdbcMutexContendServiceStopTest {
         contendService.stop()
     }
 
+    @Test
+    fun `restart failure rolls back lifecycle so stale acquisition is compensated`() {
+        val repository = BlockingMutexOwnerRepository()
+        val contender = object : AbstractMutexContender("m") {
+            override fun onAcquired(mutexState: MutexState) = Unit
+            override fun onReleased(mutexState: MutexState) = Unit
+        }
+        val contendService = JdbcMutexContendService(
+            contender,
+            Executor { it.run() },
+            repository,
+            Duration.ZERO,
+            Duration.ofSeconds(10),
+            Duration.ofSeconds(6)
+        )
+
+        contendService.start()
+        assertThat("first acquire should be in flight", repository.firstInvoked.await(2, TimeUnit.SECONDS))
+        val oldExecutor = executorOf(contendService)
+        contendService.stop()
+
+        setInitialDelay(contendService, Duration.ofSeconds(Long.MAX_VALUE))
+        assertThrows<ArithmeticException> { contendService.start() }
+        val failedExecutor = executorOf(contendService)
+
+        repository.unblockFirst.countDown()
+        assertThat("stale task should finish", oldExecutor.awaitTermination(2, TimeUnit.SECONDS))
+
+        assertThat(failedExecutor.isShutdown, equalTo(true))
+        assertThat(repository.compensatingRelease.await(1, TimeUnit.SECONDS), equalTo(true))
+        assertThat(repository.ownerId.get(), equalTo(""))
+    }
+
     private fun executorOf(contendService: JdbcMutexContendService): ScheduledThreadPoolExecutor {
         val executorField = JdbcMutexContendService::class.java.getDeclaredField("executorService")
         executorField.isAccessible = true
         return executorField.get(contendService) as ScheduledThreadPoolExecutor
+    }
+
+    private fun setInitialDelay(contendService: JdbcMutexContendService, initialDelay: Duration) {
+        val initialDelayField = JdbcMutexContendService::class.java.getDeclaredField("initialDelay")
+        initialDelayField.isAccessible = true
+        initialDelayField.set(contendService, initialDelay)
     }
 
     private class BlockingMutexOwnerRepository : MutexOwnerRepository {


### PR DESCRIPTION
## What changed

- assign each JDBC contention loop a lifecycle generation
- prevent stopped or stale tasks from scheduling onto a restarted executor
- compensate ownership acquired after stop when no newer lifecycle is active
- serialize restart and compensation decisions so a stale task cannot release the restarted lifecycle's lease
- add deterministic tests for both orphan-lock compensation and immediate restart safety

## Root cause

JDBC calls are not reliably interruptible. `stop()` could cancel the future and release the row while an older `acquireAndGetOwner()` call remained blocked; that call could then complete successfully after stop and leave an orphan owner until lease expiry.

A generation-only implementation that always releases stale ownership is also unsafe because restarted lifecycles reuse the same `contenderId`; an old task could release ownership already adopted by the restart. The lifecycle lock makes the decision atomic: compensate only when no newer active lifecycle exists.

## Impact

Stopped services no longer leave post-stop JDBC ownership behind, stale tasks cannot create a second scheduling chain after restart, and immediate restart ownership remains intact.

## Validation

- reproduced the orphan owner before the implementation with `JdbcMutexContendServiceStopTest`
- `./gradlew :simba-jdbc:test --tests me.ahoo.simba.jdbc.JdbcMutexContendServiceStopTest --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `./gradlew :simba-jdbc:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1` with MySQL 8.0 Docker
- `git diff --check`

Supersedes the closed stacked PR #451 with a clean branch based on current `main`.
