### PR TITLE
fix(jdbc): revoke owner when renewal fails

### DIFF
--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
@@ -112,7 +112,16 @@ class JdbcMutexContendService(
             log.error(throwable) {
                 "safeHandleContend - mutex:[$mutex] contenderId:[$contenderId] - failed:[${throwable.message}]."
             }
+            revokeOwnerOnFailure(generation)
             nextSchedule(ttl.toMillis(), generation)
+        }
+    }
+
+    private fun revokeOwnerOnFailure(generation: Long) {
+        synchronized(lifecycleLock) {
+            if (status.isActive && generation == activeGeneration && isOwner) {
+                notifyOwner(MutexOwner.NONE)
+            }
         }
     }
 

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceRenewalFailureTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceRenewalFailureTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.jdbc
+
+import me.ahoo.simba.core.AbstractMutexContender
+import me.ahoo.simba.core.MutexState
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class JdbcMutexContendServiceRenewalFailureTest {
+    @Test
+    fun `renewal failure revokes local ownership`() {
+        val acquired = CountDownLatch(1)
+        val renewalAttempted = CountDownLatch(1)
+        val released = CountDownLatch(1)
+        val attempts = AtomicInteger()
+        val repository = object : MutexOwnerRepository {
+            override fun initMutex(mutex: String) = true
+            override fun tryInitMutex(mutex: String) = true
+
+            override fun getOwner(mutex: String): MutexOwnerEntity {
+                throw NotFoundMutexOwnerException("not expected in this test")
+            }
+
+            override fun acquire(mutex: String, contenderId: String, ttl: Long, transition: Long) = false
+
+            override fun acquireAndGetOwner(
+                mutex: String,
+                contenderId: String,
+                ttl: Long,
+                transition: Long
+            ): MutexOwnerEntity {
+                if (attempts.getAndIncrement() == 0) {
+                    val now = System.currentTimeMillis()
+                    return MutexOwnerEntity(mutex, contenderId, now, now + 50, now + 100).also {
+                        it.currentDbAt = now
+                    }
+                }
+                renewalAttempted.countDown()
+                throw IllegalStateException("database unavailable")
+            }
+
+            override fun release(mutex: String, contenderId: String) = true
+
+            override fun ensureOwner(mutex: String): MutexOwnerEntity {
+                throw NotFoundMutexOwnerException("not expected in this test")
+            }
+        }
+        val contender = object : AbstractMutexContender("lease-expiry") {
+            override fun onAcquired(mutexState: MutexState) {
+                acquired.countDown()
+            }
+
+            override fun onReleased(mutexState: MutexState) {
+                released.countDown()
+            }
+        }
+        val contendService = JdbcMutexContendService(
+            contender,
+            Executor { it.run() },
+            repository,
+            Duration.ZERO,
+            Duration.ofMillis(100),
+            Duration.ofMillis(50)
+        )
+
+        try {
+            contendService.start()
+            assertThat("initial acquisition should succeed", acquired.await(1, TimeUnit.SECONDS))
+            assertThat("renewal should be attempted", renewalAttempted.await(1, TimeUnit.SECONDS))
+            assertThat("renewal failure should revoke local ownership", released.await(300, TimeUnit.MILLISECONDS))
+            assertThat(contendService.isOwner, equalTo(false))
+        } finally {
+            if (contendService.running) {
+                contendService.stop()
+            }
+        }
+    }
+}

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceStopTest.kt
@@ -127,6 +127,46 @@ class JdbcMutexContendServiceStopTest {
     }
 
     @Test
+    fun `stale failure does not revoke restarted lifecycle ownership`() {
+        val repository = BlockingMutexOwnerRepository()
+        repository.firstFailure = IllegalStateException("stale database failure")
+        val acquired = CountDownLatch(1)
+        val released = AtomicInteger()
+        val contender = object : AbstractMutexContender("m") {
+            override fun onAcquired(mutexState: MutexState) {
+                acquired.countDown()
+            }
+
+            override fun onReleased(mutexState: MutexState) {
+                released.incrementAndGet()
+            }
+        }
+        val contendService = JdbcMutexContendService(
+            contender,
+            Executor { it.run() },
+            repository,
+            Duration.ZERO,
+            Duration.ofSeconds(10),
+            Duration.ofSeconds(6)
+        )
+
+        contendService.start()
+        assertThat("first acquire should be in flight", repository.firstInvoked.await(2, TimeUnit.SECONDS))
+        val oldExecutor = executorOf(contendService)
+
+        contendService.stop()
+        contendService.start()
+        assertThat("restarted lifecycle should acquire", acquired.await(2, TimeUnit.SECONDS))
+
+        repository.unblockFirst.countDown()
+        assertThat("stale task should finish", oldExecutor.awaitTermination(2, TimeUnit.SECONDS))
+
+        assertThat(contendService.isOwner, equalTo(true))
+        assertThat(released.get(), equalTo(0))
+        contendService.stop()
+    }
+
+    @Test
     fun `restart failure rolls back lifecycle so stale acquisition is compensated`() {
         val repository = BlockingMutexOwnerRepository()
         val contender = object : AbstractMutexContender("m") {
@@ -172,6 +212,7 @@ class JdbcMutexContendServiceStopTest {
     }
 
     private class BlockingMutexOwnerRepository : MutexOwnerRepository {
+        var firstFailure: Throwable? = null
         val firstInvoked = CountDownLatch(1)
         val unblockFirst = CountDownLatch(1)
         val firstCompleted = CountDownLatch(1)
@@ -205,6 +246,7 @@ class JdbcMutexContendServiceStopTest {
                     } catch (_: InterruptedException) {
                     }
                 }
+                firstFailure?.let { throw it }
             }
             ownerId.set(contenderId)
             if (attempt == 1) {

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceTest.kt
@@ -13,11 +13,19 @@
 package me.ahoo.simba.jdbc
 
 import com.zaxxer.hikari.HikariDataSource
+import me.ahoo.simba.core.AbstractMutexContender
 import me.ahoo.simba.core.MutexContendServiceFactory
+import me.ahoo.simba.core.MutexState
 import me.ahoo.simba.test.MutexContendServiceSpec
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * @author ahoo wang
@@ -47,5 +55,84 @@ internal class JdbcMutexContendServiceTest : MutexContendServiceSpec() {
         jdbcMutexOwnerRepository.tryInitMutex(GUARD_MUTEX)
         jdbcMutexOwnerRepository.tryInitMutex(MULTI_CONTEND_MUTEX)
         jdbcMutexOwnerRepository.tryInitMutex(SCHEDULE_MUTEX)
+    }
+
+    @Test
+    fun `old owner is revoked before another contender acquires after renewal failure`() {
+        val mutex = "renewal-failure-${System.nanoTime()}"
+        jdbcMutexOwnerRepository.ensureOwner(mutex)
+        val ownerAAcquired = CountDownLatch(1)
+        val ownerAReleased = CountDownLatch(1)
+        val ownerBAcquired = CountDownLatch(1)
+        val attempts = AtomicInteger()
+        val eventSequence = AtomicInteger()
+        val ownerAReleasedAt = AtomicInteger()
+        val ownerBAcquiredAt = AtomicInteger()
+        val partitionedRepository = object : MutexOwnerRepository by jdbcMutexOwnerRepository {
+            override fun acquireAndGetOwner(
+                mutex: String,
+                contenderId: String,
+                ttl: Long,
+                transition: Long
+            ): MutexOwnerEntity {
+                if (attempts.getAndIncrement() == 0) {
+                    return jdbcMutexOwnerRepository.acquireAndGetOwner(mutex, contenderId, ttl, transition)
+                }
+                throw IllegalStateException("owner A cannot renew")
+            }
+        }
+        val ownerA = object : AbstractMutexContender(mutex, "owner-a") {
+            override fun onAcquired(mutexState: MutexState) {
+                ownerAAcquired.countDown()
+            }
+
+            override fun onReleased(mutexState: MutexState) {
+                ownerAReleasedAt.set(eventSequence.incrementAndGet())
+                ownerAReleased.countDown()
+            }
+        }
+        val ownerB = object : AbstractMutexContender(mutex, "owner-b") {
+            override fun onAcquired(mutexState: MutexState) {
+                ownerBAcquiredAt.set(eventSequence.incrementAndGet())
+                ownerBAcquired.countDown()
+            }
+        }
+        val ownerAService = JdbcMutexContendService(
+            ownerA,
+            Runnable::run,
+            partitionedRepository,
+            Duration.ZERO,
+            Duration.ofMillis(200),
+            Duration.ofMillis(100)
+        )
+        val ownerBService = JdbcMutexContendService(
+            ownerB,
+            Runnable::run,
+            jdbcMutexOwnerRepository,
+            Duration.ZERO,
+            Duration.ofMillis(200),
+            Duration.ofMillis(100)
+        )
+
+        try {
+            ownerAService.start()
+            assertThat("owner A should acquire first", ownerAAcquired.await(2, TimeUnit.SECONDS))
+            ownerBService.start()
+            assertThat("owner A should revoke local ownership", ownerAReleased.await(2, TimeUnit.SECONDS))
+            assertThat("owner B should acquire after A's lease expires", ownerBAcquired.await(5, TimeUnit.SECONDS))
+
+            assertThat(ownerAReleasedAt.get() < ownerBAcquiredAt.get(), equalTo(true))
+            assertThat(ownerAService.isOwner, equalTo(false))
+            assertThat(ownerBService.isOwner, equalTo(true))
+        } finally {
+            if (ownerBService.running) {
+                ownerBService.stop()
+            }
+            if (ownerAService.running) {
+                ownerAService.stop()
+            }
+            jdbcMutexOwnerRepository.release(mutex, "owner-a")
+            jdbcMutexOwnerRepository.release(mutex, "owner-b")
+        }
     }
 }


### PR DESCRIPTION
## What changed

- revoke local JDBC ownership when the active lifecycle's contention or renewal attempt fails
- keep non-owner failures on the existing retry path
- ignore failures from stale generations so they cannot revoke a restarted lifecycle
- add deterministic renewal-failure and stale-generation tests
- add a real MySQL two-contender test proving the old owner is revoked before its successor starts work

## Root cause

The JDBC failure path logged and retried without changing local owner state. Once the database lease expired, another process could acquire the row while the partitioned process continued running owner work indefinitely.

The revocation is fenced by the lifecycle lock and generation: only the current active lifecycle may publish `NONE`.

## Impact

Owner work stops promptly when renewal cannot be confirmed, preventing split-brain execution after another contender takes the database lease. Ordinary non-owner acquisition failures still retry without emitting release callbacks.

## Validation

- reproduced the missing `onReleased` callback before implementation
- deterministic `JdbcMutexContendServiceRenewalFailureTest`
- restart isolation coverage in `JdbcMutexContendServiceStopTest`
- real MySQL 8 two-contender ordering test in `JdbcMutexContendServiceTest`
- `./gradlew :simba-jdbc:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `git diff --check`

Supersedes the closed stacked PR #452 with a clean branch based on current `main`.
