### PR TITLE
fix(redis): revoke owner when renewal fails

### DIFF
--- a/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
+++ b/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
@@ -78,6 +78,9 @@ class SpringRedisMutexContendService(
     private val listenTopics: List<ChannelTopic> = listOf(ChannelTopic(mutexChannel), ChannelTopic(contenderChannel))
     private val contendPeriod: ContendPeriod = ContendPeriod(contenderId)
     private val mutexMessageListener: MutexMessageListener = MutexMessageListener()
+    private val lifecycleLock = Any()
+    private var lifecycleGeneration = 0L
+    private var activeGeneration: Long? = null
 
     /**
      * Written by the scheduling executor thread and cancelled by the stopping thread;
@@ -95,12 +98,27 @@ class SpringRedisMutexContendService(
      * 3. 开始守护
      *
      */
+    @Suppress("TooGenericExceptionCaught")
     override fun startContend() {
         log.info {
             "startContend - mutex:[$mutex] contenderId:[$contenderId]."
         }
-        startSubscribe()
-        nextSchedule(0)
+        synchronized(lifecycleLock) {
+            startSubscribe()
+            val generation = ++lifecycleGeneration
+            activeGeneration = generation
+            try {
+                nextSchedule(0, generation)
+            } catch (error: Throwable) {
+                activeGeneration = null
+                try {
+                    stopSubscribe()
+                } catch (cleanupError: Throwable) {
+                    error.addSuppressed(cleanupError)
+                }
+                throw error
+            }
+        }
     }
 
     /**
@@ -110,50 +128,88 @@ class SpringRedisMutexContendService(
         listenerContainer.addMessageListener(mutexMessageListener, listenTopics)
     }
 
-    private fun nextSchedule(nextDelay: Long) {
-        log.debug {
-            "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] status:[$status] delay:[${nextDelay}ms]."
-        }
+    private fun nextSchedule(nextDelay: Long, generation: Long) {
+        synchronized(lifecycleLock) {
+            log.debug {
+                "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] status:[$status] delay:[${nextDelay}ms]."
+            }
 
-        if (!status.isActive) {
-            log.warn {
-                "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] is not active[$status]."
+            if (!status.isActive || generation != activeGeneration) {
+                log.warn {
+                    "nextSchedule - mutex:[$mutex] contenderId:[$contenderId] is not active[$status]."
+                }
+                return
             }
-            return
+            scheduleFuture = scheduledExecutorService.schedule<MutexOwner>({
+                safeContend(generation)
+            }, nextDelay, TimeUnit.MILLISECONDS)
         }
-        scheduleFuture = scheduledExecutorService.schedule<MutexOwner>({
-            if (isOwner) {
-                return@schedule guard()
-            }
-            acquire()
-        }, nextDelay, TimeUnit.MILLISECONDS)
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun notifyOwnerAndScheduleNext(resultStr: String): MutexOwner {
+    private fun safeContend(generation: Long): MutexOwner {
         return try {
-            val result: AcquireResult = AcquireResult.of(resultStr)
-            val mutexOwner = newMutexOwner(result)
-            notifyOwner(mutexOwner)
-            val nextDelay = contendPeriod.ensureNextDelay(mutexOwner)
-            nextSchedule(nextDelay)
-            mutexOwner
+            if (isOwner) {
+                guard(generation)
+            } else {
+                acquire(generation)
+            }
         } catch (throwable: Throwable) {
-            log.error(throwable) { "notifyOwnerAndScheduleNext - mutex:[$mutex] contenderId:[$contenderId] error." }
-            nextSchedule(ttl.toMillis())
+            log.error(throwable) {
+                "safeContend - mutex:[$mutex] contenderId:[$contenderId] error."
+            }
+            revokeOwnerOnFailure(generation)
+            nextSchedule(ttl.toMillis(), generation)
             MutexOwner.NONE
         }
     }
 
-    private fun guard(): MutexOwner {
+    private fun revokeOwnerOnFailure(generation: Long) {
+        synchronized(lifecycleLock) {
+            if (status.isActive && generation == activeGeneration && isOwner) {
+                notifyOwner(MutexOwner.NONE)
+            }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun notifyOwnerAndScheduleNext(resultStr: String, generation: Long): MutexOwner {
+        return try {
+            val result: AcquireResult = AcquireResult.of(resultStr)
+            val mutexOwner = newMutexOwner(result)
+            if (!notifyOwnerIfActive(generation, mutexOwner)) {
+                return MutexOwner.NONE
+            }
+            val nextDelay = contendPeriod.ensureNextDelay(mutexOwner)
+            nextSchedule(nextDelay, generation)
+            mutexOwner
+        } catch (throwable: Throwable) {
+            log.error(throwable) { "notifyOwnerAndScheduleNext - mutex:[$mutex] contenderId:[$contenderId] error." }
+            revokeOwnerOnFailure(generation)
+            nextSchedule(ttl.toMillis(), generation)
+            MutexOwner.NONE
+        }
+    }
+
+    private fun notifyOwnerIfActive(generation: Long, mutexOwner: MutexOwner): Boolean {
+        return synchronized(lifecycleLock) {
+            if (!status.isActive || generation != activeGeneration) {
+                return@synchronized false
+            }
+            notifyOwner(mutexOwner)
+            true
+        }
+    }
+
+    private fun guard(generation: Long): MutexOwner {
         val message = redisTemplate.execute(SCRIPT_GUARD, keys, contenderId, ttl.toMillis().toString())
         log.debug {
             "guard - mutex:[$mutex] contenderId:[$contenderId] - message:[$message]."
         }
-        return notifyOwnerAndScheduleNext(message)
+        return notifyOwnerAndScheduleNext(message, generation)
     }
 
-    private fun acquire(): MutexOwner {
+    private fun acquire(generation: Long): MutexOwner {
         val message = redisTemplate.execute(
             SCRIPT_ACQUIRE,
             keys,
@@ -163,7 +219,7 @@ class SpringRedisMutexContendService(
         log.debug {
             "acquire - mutex:[$mutex] contenderId:[$contenderId] - message:[$message]."
         }
-        return notifyOwnerAndScheduleNext(message)
+        return notifyOwnerAndScheduleNext(message, generation)
     }
 
     private fun newMutexOwner(result: AcquireResult): MutexOwner {
@@ -189,9 +245,12 @@ class SpringRedisMutexContendService(
         log.info {
             "stopContend - mutex:[$mutex] contenderId:[$contenderId]."
         }
-        stopSubscribe()
-        disposeSchedule()
-        release()
+        synchronized(lifecycleLock) {
+            activeGeneration = null
+            stopSubscribe()
+            disposeSchedule()
+            release()
+        }
     }
 
     /**
@@ -240,7 +299,10 @@ class SpringRedisMutexContendService(
             when (ownerEvent.event) {
                 OwnerEvent.EVENT_RELEASED -> {
                     notifyOwner(MutexOwner.NONE)
-                    acquire()
+                    val generation = synchronized(lifecycleLock) { activeGeneration }
+                    if (generation != null) {
+                        acquire(generation)
+                    }
                 }
 
                 OwnerEvent.EVENT_ACQUIRED -> {

--- a/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceLeaseTest.kt
+++ b/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceLeaseTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.spring.redis
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.simba.core.AbstractMutexContender
+import me.ahoo.simba.core.MutexState
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.RedisConnectionFailureException
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class SpringRedisMutexContendServiceLeaseTest {
+    @Test
+    fun `renewal failure revokes local ownership`() {
+        val acquired = CountDownLatch(1)
+        val released = CountDownLatch(1)
+        val contender = object : AbstractMutexContender("lease-expiry", "lease-owner") {
+            override fun onAcquired(mutexState: MutexState) {
+                acquired.countDown()
+            }
+
+            override fun onReleased(mutexState: MutexState) {
+                released.countDown()
+            }
+        }
+        val redisTemplate = mockk<StringRedisTemplate>(relaxed = true)
+        every {
+            redisTemplate.execute(
+                match<RedisScript<String>> { it.resultType == String::class.java },
+                any<List<String>>(),
+                *anyVararg()
+            )
+        } returns "${contender.contenderId}@@100" andThenThrows
+            RedisConnectionFailureException("unavailable")
+        every {
+            redisTemplate.execute(
+                match<RedisScript<Boolean>> { it.resultType == Boolean::class.java },
+                any<List<String>>(),
+                *anyVararg()
+            )
+        } returns true
+        val scheduler = ScheduledThreadPoolExecutor(1)
+        val service = SpringRedisMutexContendService(
+            contender,
+            Runnable::run,
+            Duration.ofMillis(50),
+            Duration.ofMillis(50),
+            redisTemplate,
+            mockk<RedisMessageListenerContainer>(relaxed = true),
+            scheduler
+        )
+
+        try {
+            service.start()
+            assertThat("initial acquisition should succeed", acquired.await(1, TimeUnit.SECONDS))
+            assertThat("renewal failure should revoke ownership", released.await(300, TimeUnit.MILLISECONDS))
+            assertThat(service.isOwner, equalTo(false))
+        } finally {
+            if (service.running) {
+                service.stop()
+            }
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Suppress("LongMethod")
+    @Test
+    fun `stale failure does not revoke restarted lifecycle ownership`() {
+        val firstInvoked = CountDownLatch(1)
+        val unblockFirst = CountDownLatch(1)
+        val acquired = CountDownLatch(1)
+        val released = AtomicInteger()
+        val calls = AtomicInteger()
+        val contender = object : AbstractMutexContender("restart-lease", "lease-owner") {
+            override fun onAcquired(mutexState: MutexState) {
+                acquired.countDown()
+            }
+
+            override fun onReleased(mutexState: MutexState) {
+                released.incrementAndGet()
+            }
+        }
+        val redisTemplate = mockk<StringRedisTemplate>(relaxed = true)
+        every {
+            redisTemplate.execute(
+                match<RedisScript<String>> { it.resultType == String::class.java },
+                any<List<String>>(),
+                *anyVararg()
+            )
+        } answers {
+            if (calls.getAndIncrement() == 0) {
+                firstInvoked.countDown()
+                while (unblockFirst.count > 0) {
+                    try {
+                        unblockFirst.await()
+                    } catch (_: InterruptedException) {
+                    }
+                }
+                throw RedisConnectionFailureException("stale failure")
+            }
+            "${contender.contenderId}@@${Long.MAX_VALUE}"
+        }
+        every {
+            redisTemplate.execute(
+                match<RedisScript<Boolean>> { it.resultType == Boolean::class.java },
+                any<List<String>>(),
+                *anyVararg()
+            )
+        } returns true
+        val scheduler = CompletionTrackingScheduler()
+        val service = SpringRedisMutexContendService(
+            contender,
+            Runnable::run,
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(1),
+            redisTemplate,
+            mockk<RedisMessageListenerContainer>(relaxed = true),
+            scheduler
+        )
+
+        try {
+            service.start()
+            assertThat("first Redis call should be in flight", firstInvoked.await(1, TimeUnit.SECONDS))
+            service.stop()
+            service.start()
+            assertThat("restarted lifecycle should acquire", acquired.await(1, TimeUnit.SECONDS))
+
+            unblockFirst.countDown()
+            assertThat("both lifecycle tasks should finish", scheduler.completed.await(2, TimeUnit.SECONDS))
+
+            assertThat(service.isOwner, equalTo(true))
+            assertThat(released.get(), equalTo(0))
+        } finally {
+            unblockFirst.countDown()
+            if (service.running) {
+                service.stop()
+            }
+            scheduler.shutdownNow()
+        }
+    }
+
+    private class CompletionTrackingScheduler : ScheduledThreadPoolExecutor(2) {
+        val completed = CountDownLatch(2)
+
+        override fun afterExecute(runnable: Runnable, throwable: Throwable?) {
+            super.afterExecute(runnable, throwable)
+            completed.countDown()
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- wrap Redis acquire and guard commands in a failure boundary that keeps the scheduler alive
- revoke local ownership when the current lifecycle cannot confirm renewal
- fence Redis notifications, retries, and revocation by lifecycle generation
- prevent stale failures from revoking a restarted lifecycle
- add deterministic short-lease and stop/restart failure coverage

## Root cause

Redis command failures occurred before `notifyOwnerAndScheduleNext`, so they escaped the scheduled callable. The task chain stopped permanently while local owner state remained true, allowing owner work to continue after the Redis lease expired.

A lifecycle fence is required because an in-flight command from before stop can fail after restart; that stale failure must not publish `NONE` into the new lifecycle.

## Impact

Owner work stops when renewal cannot be confirmed, non-owner failures continue retrying, and restart ownership is isolated from stale Redis tasks.

## Validation

- reproduced missing release after renewal failure before implementation
- reproduced stale failure revoking restarted ownership before lifecycle fencing
- `./gradlew :simba-spring-redis:test --tests me.ahoo.simba.spring.redis.SpringRedisMutexContendServiceLeaseTest --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `./gradlew :simba-spring-redis:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `git diff --check`

Supersedes the closed stacked PR #453 with a clean branch based on current `main`.
