### PR TITLE
fix(redis): keep a single contention schedule

### DIFF
--- a/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
+++ b/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
@@ -81,6 +81,7 @@ class SpringRedisMutexContendService(
     private val lifecycleLock = Any()
     private var lifecycleGeneration = 0L
     private var activeGeneration: Long? = null
+    private var scheduleToken = 0L
 
     /**
      * Written by the scheduling executor thread and cancelled by the stopping thread;
@@ -140,10 +141,22 @@ class SpringRedisMutexContendService(
                 }
                 return
             }
+            val token = ++scheduleToken
+            scheduleFuture?.cancel(true)
             scheduleFuture = scheduledExecutorService.schedule<MutexOwner>({
-                safeContend(generation)
+                runScheduled(generation, token)
             }, nextDelay, TimeUnit.MILLISECONDS)
         }
+    }
+
+    private fun runScheduled(generation: Long, token: Long): MutexOwner {
+        synchronized(lifecycleLock) {
+            if (!status.isActive || generation != activeGeneration || token != scheduleToken) {
+                return MutexOwner.NONE
+            }
+            scheduleFuture = null
+        }
+        return safeContend(generation)
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -177,7 +190,7 @@ class SpringRedisMutexContendService(
         return try {
             val result: AcquireResult = AcquireResult.of(resultStr)
             val mutexOwner = newMutexOwner(result)
-            if (!notifyOwnerIfActive(generation, mutexOwner)) {
+            if (!notifyOwnerOrCompensate(generation, mutexOwner)) {
                 return MutexOwner.NONE
             }
             val nextDelay = contendPeriod.ensureNextDelay(mutexOwner)
@@ -191,13 +204,19 @@ class SpringRedisMutexContendService(
         }
     }
 
-    private fun notifyOwnerIfActive(generation: Long, mutexOwner: MutexOwner): Boolean {
+    private fun notifyOwnerOrCompensate(generation: Long, mutexOwner: MutexOwner): Boolean {
         return synchronized(lifecycleLock) {
-            if (!status.isActive || generation != activeGeneration) {
-                return@synchronized false
+            val currentGeneration = activeGeneration
+            if (status.isActive && generation == currentGeneration) {
+                notifyOwner(mutexOwner)
+                return@synchronized true
             }
-            notifyOwner(mutexOwner)
-            true
+            if (mutexOwner.isOwner(contenderId) &&
+                (currentGeneration == null || generation == currentGeneration)
+            ) {
+                releaseRemote()
+            }
+            false
         }
     }
 
@@ -261,15 +280,20 @@ class SpringRedisMutexContendService(
     }
 
     private fun disposeSchedule() {
-        scheduleFuture?.let {
-            it.cancel(true)
+        synchronized(lifecycleLock) {
+            scheduleToken++
+            scheduleFuture?.cancel(true)
             scheduleFuture = null
         }
     }
 
+    private fun releaseRemote(): Boolean {
+        return redisTemplate.execute(SCRIPT_RELEASE, keys, contenderId)
+    }
+
     @Suppress("TooGenericExceptionCaught")
     private fun release() {
-        val succeed = redisTemplate.execute(SCRIPT_RELEASE, keys, contenderId)
+        val succeed = releaseRemote()
         log.debug {
             "release - mutex:[$mutex] - contenderId:[$contenderId] - succeed:[$succeed]"
         }
@@ -301,7 +325,7 @@ class SpringRedisMutexContendService(
                     notifyOwner(MutexOwner.NONE)
                     val generation = synchronized(lifecycleLock) { activeGeneration }
                     if (generation != null) {
-                        acquire(generation)
+                        nextSchedule(0, generation)
                     }
                 }
 

--- a/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceLeaseTest.kt
+++ b/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceLeaseTest.kt
@@ -159,6 +159,67 @@ class SpringRedisMutexContendServiceLeaseTest {
         }
     }
 
+    @Test
+    fun `acquisition completing after stop is released remotely`() {
+        val firstInvoked = CountDownLatch(1)
+        val unblockFirst = CountDownLatch(1)
+        val compensated = CountDownLatch(1)
+        val releaseCalls = AtomicInteger()
+        val contender = object : AbstractMutexContender("stopped-acquire", "lease-owner") {}
+        val redisTemplate = mockk<StringRedisTemplate>(relaxed = true)
+        every {
+            redisTemplate.execute(
+                match<RedisScript<String>> { it.resultType == String::class.java },
+                any<List<String>>(),
+                *anyVararg()
+            )
+        } answers {
+            firstInvoked.countDown()
+            while (unblockFirst.count > 0) {
+                try {
+                    unblockFirst.await()
+                } catch (_: InterruptedException) {
+                }
+            }
+            "${contender.contenderId}@@${Long.MAX_VALUE}"
+        }
+        every {
+            redisTemplate.execute(
+                match<RedisScript<Boolean>> { it.resultType == Boolean::class.java },
+                any<List<String>>(),
+                *anyVararg()
+            )
+        } answers {
+            if (releaseCalls.incrementAndGet() == 2) {
+                compensated.countDown()
+            }
+            true
+        }
+        val scheduler = ScheduledThreadPoolExecutor(1)
+        val service = SpringRedisMutexContendService(
+            contender,
+            Runnable::run,
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(1),
+            redisTemplate,
+            mockk<RedisMessageListenerContainer>(relaxed = true),
+            scheduler
+        )
+
+        try {
+            service.start()
+            assertThat("Redis acquire should be in flight", firstInvoked.await(1, TimeUnit.SECONDS))
+            service.stop()
+            unblockFirst.countDown()
+
+            assertThat("late acquisition should be compensated", compensated.await(1, TimeUnit.SECONDS))
+            assertThat(releaseCalls.get(), equalTo(2))
+        } finally {
+            unblockFirst.countDown()
+            scheduler.shutdownNow()
+        }
+    }
+
     private class CompletionTrackingScheduler : ScheduledThreadPoolExecutor(2) {
         val completed = CountDownLatch(2)
 

--- a/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceSchedulingTest.kt
+++ b/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceSchedulingTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.spring.redis
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.simba.core.AbstractMutexContender
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.DefaultMessage
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import java.time.Duration
+import java.util.concurrent.Callable
+import java.util.concurrent.Delayed
+import java.util.concurrent.FutureTask
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class SpringRedisMutexContendServiceSchedulingTest {
+    @Test
+    fun `released event replaces the pending retry`() {
+        val contender = object : AbstractMutexContender("released", "released-owner") {}
+        val redisTemplate = stringRedisTemplateReturning("other@@15000")
+        val scheduler = ManualScheduledExecutor()
+        val service = newService(contender, redisTemplate, scheduler)
+
+        service.start()
+        scheduler.run(0)
+        service.MutexMessageListener().onMessage(
+            DefaultMessage(
+                "simba:{released}:${contender.contenderId}".toByteArray(),
+                "released@@other".toByteArray()
+            ),
+            null
+        )
+
+        assertThat(scheduler.pendingTaskCount, equalTo(1))
+        scheduler.shutdownNow()
+    }
+
+    @Test
+    fun `stop prevents a superseded future from acquiring`() {
+        val contender = object : AbstractMutexContender("stopped", "stopped-owner") {}
+        val acquireCalls = AtomicInteger()
+        val redisTemplate = stringRedisTemplateReturning("other@@15000", acquireCalls)
+        every {
+            redisTemplate.execute(
+                match<RedisScript<Boolean>> { it.resultType == Boolean::class.java },
+                any<List<String>>(),
+                *anyVararg()
+            )
+        } returns true
+        val scheduler = ManualScheduledExecutor()
+        val service = newService(contender, redisTemplate, scheduler)
+
+        service.start()
+        scheduler.run(0)
+        service.MutexMessageListener().onMessage(
+            DefaultMessage(
+                "simba:{stopped}:${contender.contenderId}".toByteArray(),
+                "released@@other".toByteArray()
+            ),
+            null
+        )
+        val callsBeforeStop = acquireCalls.get()
+
+        service.stop()
+        scheduler.runActive()
+
+        assertThat(acquireCalls.get(), equalTo(callsBeforeStop))
+        scheduler.shutdownNow()
+    }
+
+    private fun stringRedisTemplateReturning(
+        result: String,
+        calls: AtomicInteger = AtomicInteger()
+    ): StringRedisTemplate {
+        return mockk<StringRedisTemplate>(relaxed = true).also { redisTemplate ->
+            every {
+                redisTemplate.execute(
+                    match<RedisScript<String>> { it.resultType == String::class.java },
+                    any<List<String>>(),
+                    *anyVararg()
+                )
+            } answers {
+                calls.incrementAndGet()
+                result
+            }
+        }
+    }
+
+    private fun newService(
+        contender: AbstractMutexContender,
+        redisTemplate: StringRedisTemplate,
+        scheduler: ScheduledThreadPoolExecutor
+    ): SpringRedisMutexContendService {
+        return SpringRedisMutexContendService(
+            contender,
+            Runnable::run,
+            Duration.ofSeconds(5),
+            Duration.ofSeconds(10),
+            redisTemplate,
+            mockk<RedisMessageListenerContainer>(relaxed = true),
+            scheduler
+        )
+    }
+
+    private class ManualScheduledExecutor : ScheduledThreadPoolExecutor(1) {
+        private val tasks = mutableListOf<ManualScheduledFuture<*>>()
+
+        override fun <V : Any?> schedule(
+            callable: Callable<V>,
+            delay: Long,
+            unit: TimeUnit
+        ): ScheduledFuture<V> {
+            return ManualScheduledFuture(callable).also { tasks += it }
+        }
+
+        fun run(index: Int) {
+            tasks[index].run()
+        }
+
+        fun runActive() {
+            tasks.toList().forEach {
+                if (!it.isDone && !it.isCancelled) {
+                    it.run()
+                }
+            }
+        }
+
+        val pendingTaskCount: Int
+            get() = tasks.count { !it.isDone && !it.isCancelled }
+    }
+
+    private class ManualScheduledFuture<V>(callable: Callable<V>) :
+        FutureTask<V>(callable),
+        ScheduledFuture<V> {
+        override fun getDelay(unit: TimeUnit): Long = 0
+        override fun compareTo(other: Delayed): Int = 0
+    }
+}


### PR DESCRIPTION
## What changed

- maintain one pending Redis contention task per service with a schedule token
- cancel superseded retries before scheduling immediate release wakeups
- validate lifecycle generation and token before a scheduled task may run
- route release messages through the scheduler instead of synchronous Redis access
- compensate ownership acquired after stop when no restarted lifecycle is active
- preserve ownership adopted by an active restarted lifecycle

## Root cause

A targeted `released` message performed an immediate acquire while the existing retry remained scheduled. Both paths then scheduled successors, but the service retained only the newest future. Stop cancelled one chain while older tasks remained able to execute and reacquire the Redis lock after shutdown.

## Impact

Each service now has one contention chain, release wakeups replace pending retries, and stale tasks cannot acquire or reschedule after stop. Late ownership is released unless a newer active lifecycle has adopted the same contender lease.

## Validation

- reproduced two pending tasks after a release event before implementation
- reproduced an acquire from a superseded future after stop before implementation
- deterministic single-chain and post-stop tests in `SpringRedisMutexContendServiceSchedulingTest`
- deterministic late-acquire compensation test in `SpringRedisMutexContendServiceLeaseTest`
- `./gradlew :simba-spring-redis:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `git diff --check`

Supersedes the closed stacked PR #454 with a clean branch based on current `main`.
