### PR TITLE
fix(starter): back off JDBC without a data source

### DIFF
--- a/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfiguration.kt
+++ b/simba-spring-boot-starter/src/main/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfiguration.kt
@@ -17,8 +17,10 @@ import me.ahoo.simba.jdbc.JdbcMutexContendServiceFactory
 import me.ahoo.simba.jdbc.JdbcMutexOwnerRepository
 import me.ahoo.simba.jdbc.MutexOwnerRepository
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import java.util.concurrent.ForkJoinPool
@@ -38,12 +40,14 @@ import javax.sql.DataSource
 class SimbaJdbcAutoConfiguration(private val jdbcProperties: JdbcProperties) {
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnSingleCandidate(DataSource::class)
     fun mutexOwnerRepository(dataSource: DataSource): MutexOwnerRepository {
         return JdbcMutexOwnerRepository(dataSource)
     }
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnBean(MutexOwnerRepository::class)
     fun jdbcMutexContendServiceFactory(mutexOwnerRepository: MutexOwnerRepository): MutexContendServiceFactory {
         return JdbcMutexContendServiceFactory(
             mutexOwnerRepository = mutexOwnerRepository,

--- a/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfigurationTest.kt
+++ b/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfigurationTest.kt
@@ -78,4 +78,43 @@ internal class SimbaJdbcAutoConfigurationTest {
                     .doesNotHaveBean(MutexContendServiceFactory::class.java)
             }
     }
+
+    @Test
+    fun contextBacksOffWithoutDataSource() {
+        contextRunner
+            .withUserConfiguration(SimbaJdbcAutoConfiguration::class.java)
+            .run {
+                assertThat(it)
+                    .hasNotFailed()
+                    .doesNotHaveBean(MutexOwnerRepository::class.java)
+                    .doesNotHaveBean(MutexContendServiceFactory::class.java)
+            }
+    }
+
+    @Test
+    fun contextLoadsWithCustomRepositoryWithoutDataSource() {
+        contextRunner
+            .withBean(MutexOwnerRepository::class.java, { mockk() })
+            .withUserConfiguration(SimbaJdbcAutoConfiguration::class.java)
+            .run {
+                assertThat(it)
+                    .hasNotFailed()
+                    .hasSingleBean(MutexOwnerRepository::class.java)
+                    .hasSingleBean(MutexContendServiceFactory::class.java)
+            }
+    }
+
+    @Test
+    fun contextBacksOffWithMultipleDataSources() {
+        contextRunner
+            .withBean("firstDataSource", DataSource::class.java, { mockk() })
+            .withBean("secondDataSource", DataSource::class.java, { mockk() })
+            .withUserConfiguration(SimbaJdbcAutoConfiguration::class.java)
+            .run {
+                assertThat(it)
+                    .hasNotFailed()
+                    .doesNotHaveBean(MutexOwnerRepository::class.java)
+                    .doesNotHaveBean(MutexContendServiceFactory::class.java)
+            }
+    }
 }


### PR DESCRIPTION
## What changed

- create the default JDBC repository only when exactly one `DataSource` candidate exists
- create the JDBC contention factory only when a `MutexOwnerRepository` is available
- preserve custom repository support without requiring a `DataSource`
- cover missing, single, custom, and multiple DataSource configurations

## Root cause

The JDBC auto-configuration only checked for Simba JDBC classes. It still registered a repository bean with a mandatory `DataSource` parameter, so applications without a data source failed startup instead of backing off as documented.

## Impact

Including Simba's JDBC capability no longer breaks applications that have no unambiguous `DataSource`; users can still provide a custom repository to enable the factory.

## Validation

- reproduced `UnsatisfiedDependencyException` without DataSource before implementation
- `SimbaJdbcAutoConfigurationTest` covers missing/custom/multiple candidates
- `./gradlew :simba-spring-boot-starter:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- `git diff --check`

Supersedes the closed stacked PR #456 with a clean branch based on current `main`.
