### PR TITLE
fix(jdbc): advance database owner clock

### DIFF
--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/MutexOwnerEntity.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/MutexOwnerEntity.kt
@@ -13,6 +13,7 @@
 package me.ahoo.simba.jdbc
 
 import me.ahoo.simba.core.MutexOwner
+import java.util.concurrent.TimeUnit
 
 /**
  * 互斥体实体.
@@ -36,11 +37,19 @@ class MutexOwnerEntity(val mutex: String, ownerId: String, acquiredAt: Long, ttl
      * 当前Db时间戳 (统一使用Db时间作为统一时间，防止全局时间不一致).
      * [java.util.concurrent.TimeUnit.MILLISECONDS]
      */
+    @Volatile
+    private var currentDbAtNanos: Long = System.nanoTime()
+
+    @Volatile
     var currentDbAt: Long = 0
+        set(value) {
+            currentDbAtNanos = System.nanoTime()
+            field = value
+        }
 
     override val currentAt: Long
         get() = if (currentDbAt > 0) {
-            currentDbAt
+            currentDbAt + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentDbAtNanos)
         } else {
             super.currentAt
         }

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/MutexOwnerEntityClockTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/MutexOwnerEntityClockTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.jdbc
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class MutexOwnerEntityClockTest {
+    @Test
+    fun `database clock advances so ownership expires locally`() {
+        val owner = MutexOwnerEntity("m", "owner", 900, 1001, 1001)
+        owner.currentDbAt = 1000
+        assertThat(owner.isInTtl, equalTo(true))
+
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1)
+        while (owner.hasOwner() && System.nanoTime() < deadline) {
+            Thread.yield()
+        }
+
+        assertThat(owner.isInTtl, equalTo(false))
+        assertThat(owner.hasOwner(), equalTo(false))
+    }
+}


### PR DESCRIPTION
## What changed

- keep the database timestamp as the owner clock's epoch
- advance `currentAt` with monotonic JVM elapsed time after the row is read
- make DB clock publication visible across threads
- verify TTL and transition ownership expire locally without another query

## Root cause

`MutexOwnerEntity.currentAt` returned the fixed `currentDbAt` captured by the query forever. `isInTtl`, `hasOwner()`, and scheduling calculations therefore never observed time passing after the entity was created.

## Impact

JDBC owner state keeps the cross-node DB time baseline while leases now expire naturally and remain immune to JVM wall-clock adjustments.

## Validation

- reproduced a one-millisecond lease remaining active for one second before implementation
- deterministic `MutexOwnerEntityClockTest`
- `./gradlew :simba-jdbc:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1` with MySQL 8
- `git diff --check`
