### PR TITLE
fix: validate backend lease durations

### DIFF
--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcDurationValidation.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcDurationValidation.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.jdbc
+
+import java.time.Duration
+
+internal fun validateJdbcDurations(initialDelay: Duration, ttl: Duration, transition: Duration) {
+    require(!initialDelay.isNegative) { "initialDelay must not be negative: $initialDelay" }
+    require(!ttl.isNegative && !ttl.isZero) { "ttl must be positive: $ttl" }
+    require(!transition.isNegative) { "transition must not be negative: $transition" }
+
+    initialDelay.toMillisExact("initialDelay")
+    val ttlMillis = ttl.toMillisExact("ttl")
+    require(ttlMillis > 0) { "ttl must be at least 1ms: $ttl" }
+    val transitionMillis = transition.toMillisExact("transition")
+    try {
+        Math.addExact(ttlMillis, transitionMillis)
+    } catch (error: ArithmeticException) {
+        throw IllegalArgumentException("ttl + transition must fit in milliseconds", error)
+    }
+}
+
+private fun Duration.toMillisExact(name: String): Long {
+    return try {
+        toMillis()
+    } catch (error: ArithmeticException) {
+        throw IllegalArgumentException("$name must fit in milliseconds: $this", error)
+    }
+}

--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendService.kt
@@ -41,6 +41,10 @@ class JdbcMutexContendService(
         private val log = KotlinLogging.logger {}
     }
 
+    init {
+        validateJdbcDurations(initialDelay, ttl, transition)
+    }
+
     private var executorService: ScheduledThreadPoolExecutor? = null
     private val contendPeriod: ContendPeriod = ContendPeriod(contenderId)
     private val lifecycleLock = Any()

--- a/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceFactory.kt
+++ b/simba-jdbc/src/main/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceFactory.kt
@@ -31,6 +31,9 @@ class JdbcMutexContendServiceFactory(
     private val ttl: Duration,
     private val transition: Duration
 ) : MutexContendServiceFactory {
+    init {
+        validateJdbcDurations(initialDelay, ttl, transition)
+    }
 
     override fun createMutexContendService(mutexContender: MutexContender): MutexContendService {
         return JdbcMutexContendService(

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceFactoryTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceFactoryTest.kt
@@ -36,6 +36,9 @@ class JdbcMutexContendServiceFactoryTest {
         assertThrows<IllegalArgumentException> {
             newFactory(Duration.ZERO, Duration.ofMillis(Long.MAX_VALUE), Duration.ofMillis(1))
         }
+        assertThrows<IllegalArgumentException> {
+            newFactory(Duration.ofSeconds(Long.MAX_VALUE), Duration.ofMillis(1), Duration.ZERO)
+        }
     }
 
     private fun newFactory(

--- a/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceFactoryTest.kt
+++ b/simba-jdbc/src/test/kotlin/me/ahoo/simba/jdbc/JdbcMutexContendServiceFactoryTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.jdbc
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.reflect.Proxy
+import java.time.Duration
+
+class JdbcMutexContendServiceFactoryTest {
+    private val repository = Proxy.newProxyInstance(
+        javaClass.classLoader,
+        arrayOf(MutexOwnerRepository::class.java)
+    ) { _, _, _ -> throw UnsupportedOperationException() } as MutexOwnerRepository
+
+    @Test
+    fun `factory rejects invalid scheduling and lease durations`() {
+        assertThrows<IllegalArgumentException> {
+            newFactory(Duration.ofMillis(-1), Duration.ofMillis(1), Duration.ZERO)
+        }
+        assertThrows<IllegalArgumentException> { newFactory(Duration.ZERO, Duration.ZERO, Duration.ZERO) }
+        assertThrows<IllegalArgumentException> { newFactory(Duration.ZERO, Duration.ofNanos(1), Duration.ZERO) }
+        assertThrows<IllegalArgumentException> {
+            newFactory(Duration.ZERO, Duration.ofMillis(1), Duration.ofMillis(-1))
+        }
+        assertThrows<IllegalArgumentException> {
+            newFactory(Duration.ZERO, Duration.ofMillis(Long.MAX_VALUE), Duration.ofMillis(1))
+        }
+    }
+
+    private fun newFactory(
+        initialDelay: Duration,
+        ttl: Duration,
+        transition: Duration
+    ): JdbcMutexContendServiceFactory {
+        return JdbcMutexContendServiceFactory(
+            mutexOwnerRepository = repository,
+            initialDelay = initialDelay,
+            ttl = ttl,
+            transition = transition
+        )
+    }
+}

--- a/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfigurationTest.kt
+++ b/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/jdbc/SimbaJdbcAutoConfigurationTest.kt
@@ -65,6 +65,17 @@ internal class SimbaJdbcAutoConfigurationTest {
     }
 
     @Test
+    fun contextFailsFastWithInvalidTtl() {
+        contextRunner
+            .withBean(DataSource::class.java, { mockk() })
+            .withPropertyValues("simba.jdbc.ttl=0ms")
+            .withUserConfiguration(SimbaJdbcAutoConfiguration::class.java)
+            .run {
+                assertThat(it).hasFailed()
+            }
+    }
+
+    @Test
     fun contextLoadsWithDisable() {
         contextRunner
             .withBean(DataSource::class.java, { mockk() })

--- a/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/redis/SimbaSpringRedisAutoConfigurationTest.kt
+++ b/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/redis/SimbaSpringRedisAutoConfigurationTest.kt
@@ -42,4 +42,17 @@ internal class SimbaSpringRedisAutoConfigurationTest {
                     .hasSingleBean(MutexContendServiceFactory::class.java)
             }
     }
+
+    @Test
+    fun contextFailsFastWithInvalidTtl() {
+        contextRunner
+            .withPropertyValues("simba.redis.ttl=0ms")
+            .withUserConfiguration(
+                DataRedisAutoConfiguration::class.java,
+                SimbaSpringRedisAutoConfiguration::class.java
+            )
+            .run {
+                assertThat(it).hasFailed()
+            }
+    }
 }

--- a/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/RedisDurationValidation.kt
+++ b/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/RedisDurationValidation.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.spring.redis
+
+import java.time.Duration
+
+internal fun validateRedisDurations(ttl: Duration, transition: Duration) {
+    require(!ttl.isNegative && !ttl.isZero) { "ttl must be positive: $ttl" }
+    require(!transition.isNegative) { "transition must not be negative: $transition" }
+
+    val ttlMillis = ttl.toMillisExact("ttl")
+    require(ttlMillis > 0) { "ttl must be at least 1ms: $ttl" }
+    val transitionMillis = transition.toMillisExact("transition")
+    try {
+        Math.addExact(ttlMillis, transitionMillis)
+    } catch (error: ArithmeticException) {
+        throw IllegalArgumentException("ttl + transition must fit in milliseconds", error)
+    }
+}
+
+private fun Duration.toMillisExact(name: String): Long {
+    return try {
+        toMillis()
+    } catch (error: ArithmeticException) {
+        throw IllegalArgumentException("$name must fit in milliseconds: $this", error)
+    }
+}

--- a/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
+++ b/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendService.kt
@@ -58,6 +58,10 @@ class SpringRedisMutexContendService(
         private val SCRIPT_GUARD = RedisScript.of(GUARD_RESOURCE, String::class.java)
     }
 
+    init {
+        validateRedisDurations(ttl, transition)
+    }
+
     private val keys: List<String> = listOf("{${contender.mutex}}")
     private val mutexKey: String = "${Simba.SIMBA}:${keys.single()}"
 

--- a/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceFactory.kt
+++ b/simba-spring-redis/src/main/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceFactory.kt
@@ -39,6 +39,10 @@ class SpringRedisMutexContendServiceFactory(
     private val handleExecutor: Executor = ForkJoinPool.commonPool(),
     private val scheduledExecutorService: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
 ) : MutexContendServiceFactory, AutoCloseable {
+    init {
+        validateRedisDurations(ttl, transition)
+    }
+
     override fun createMutexContendService(mutexContender: MutexContender): MutexContendService {
         return SpringRedisMutexContendService(
             mutexContender,

--- a/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceFactoryTest.kt
+++ b/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceFactoryTest.kt
@@ -15,11 +15,23 @@ package me.ahoo.simba.spring.redis
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import java.time.Duration
 import java.util.concurrent.Executors
 
 class SpringRedisMutexContendServiceFactoryTest {
+    @Test
+    fun `factory rejects invalid lease durations`() {
+        assertThrows<IllegalArgumentException> { newFactory(Duration.ZERO, Duration.ZERO) }
+        assertThrows<IllegalArgumentException> { newFactory(Duration.ofNanos(1), Duration.ZERO) }
+        assertThrows<IllegalArgumentException> { newFactory(Duration.ofMillis(1), Duration.ofMillis(-1)) }
+        assertThrows<IllegalArgumentException> {
+            newFactory(Duration.ofMillis(Long.MAX_VALUE), Duration.ofMillis(1))
+        }
+    }
+
     @Test
     fun `close shuts down the scheduled executor service`() {
         val scheduledExecutorService = Executors.newScheduledThreadPool(1)
@@ -34,5 +46,15 @@ class SpringRedisMutexContendServiceFactoryTest {
         factory.close()
 
         assertThat(scheduledExecutorService.isShutdown, equalTo(true))
+    }
+
+    private fun newFactory(ttl: Duration, transition: Duration): SpringRedisMutexContendServiceFactory {
+        return SpringRedisMutexContendServiceFactory(
+            ttl = ttl,
+            transition = transition,
+            redisTemplate = StringRedisTemplate(),
+            listenerContainer = RedisMessageListenerContainer(),
+            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor().also { it.shutdown() }
+        )
     }
 }

--- a/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceFactoryTest.kt
+++ b/simba-spring-redis/src/test/kotlin/me/ahoo/simba/spring/redis/SpringRedisMutexContendServiceFactoryTest.kt
@@ -30,6 +30,7 @@ class SpringRedisMutexContendServiceFactoryTest {
         assertThrows<IllegalArgumentException> {
             newFactory(Duration.ofMillis(Long.MAX_VALUE), Duration.ofMillis(1))
         }
+        assertThrows<IllegalArgumentException> { newFactory(Duration.ofSeconds(Long.MAX_VALUE), Duration.ZERO) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- reject non-positive or sub-millisecond lease TTLs before scheduling/backend calls
- reject negative delays/transitions and millisecond overflow for JDBC and Redis
- validate both factories and directly constructed services
- cover programmatic construction and Spring Boot property binding

## Verification

- `./gradlew :simba-jdbc:check :simba-spring-redis:check :simba-spring-boot-starter:check --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- MySQL 8.0 initialized with `simba-jdbc/src/init-script/init-simba-mysql.sql`
- Redis available at `localhost:6379`
- `git diff --check`
