### PR TITLE
fix(example): stop contend service on shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ create table simba_mutex
             }
         });
         contendService.start();
+        try {
+            // Use the mutex-protected service.
+        } finally {
+            contendService.stop();
+        }
 ```
 
 ### SimbaLocker

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -123,6 +123,11 @@ create table simba_mutex
             }
         });
         contendService.start();
+        try {
+            // 使用互斥保护的服务。
+        } finally {
+            contendService.stop();
+        }
 ```
 
 ### SimbaLocker

--- a/simba-example/build.gradle.kts
+++ b/simba-example/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
 //    implementation(project(":simba-zookeeper"))
     implementation(project(":simba-spring-boot-starter"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/simba-example/src/main/java/me/ahoo/simba/example/ExampleApp.java
+++ b/simba-example/src/main/java/me/ahoo/simba/example/ExampleApp.java
@@ -13,6 +13,7 @@
 
 package me.ahoo.simba.example;
 
+import jakarta.annotation.PreDestroy;
 import me.ahoo.simba.core.MutexContendService;
 import me.ahoo.simba.core.MutexContendServiceFactory;
 import me.ahoo.simba.locker.SimbaLocker;
@@ -44,6 +45,7 @@ public class ExampleApp implements CommandLineRunner {
     
     @Autowired
     private MutexContendServiceFactory mutexContendServiceFactory;
+    private MutexContendService contendService;
     
     /**
      * Callback used to run the bean.
@@ -53,8 +55,15 @@ public class ExampleApp implements CommandLineRunner {
      */
     @Override
     public void run(String... args) throws Exception {
-        MutexContendService contendService = mutexContendServiceFactory.createMutexContendService(new ExampleContender());
+        contendService = mutexContendServiceFactory.createMutexContendService(new ExampleContender());
         contendService.start();
+    }
+
+    @PreDestroy
+    public void stopContendService() {
+        if (contendService != null) {
+            contendService.stop();
+        }
     }
     
     @Scheduled(initialDelay = 1000, fixedDelay = 1000)

--- a/simba-example/src/test/java/me/ahoo/simba/example/ExampleAppTest.java
+++ b/simba-example/src/test/java/me/ahoo/simba/example/ExampleAppTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.simba.example;
+
+import me.ahoo.simba.core.MutexContendService;
+import me.ahoo.simba.core.MutexContendServiceFactory;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ExampleAppTest {
+    @Test
+    void contextCloseStopsContendService() throws Exception {
+        MutexContendServiceFactory factory = mock(MutexContendServiceFactory.class);
+        MutexContendService contendService = mock(MutexContendService.class);
+        when(factory.createMutexContendService(any())).thenReturn(contendService);
+
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            context.registerBean(MutexContendServiceFactory.class, () -> factory);
+            context.registerBean(CommandLineRunner.class, ExampleApp::new);
+            context.refresh();
+            context.getBean(CommandLineRunner.class).run();
+            verify(contendService).start();
+        }
+
+        verify(contendService).stop();
+    }
+}


### PR DESCRIPTION
## Summary

- retain the example contender service and stop it during Spring shutdown
- add a context-close regression test that verifies one start and one stop
- make the example module's JUnit Platform runtime complete
- document balanced start/stop usage in both root READMEs

## Verification

- `./gradlew :simba-example:check --no-daemon --max-workers=1`
- `git diff --check`
