### PR TITLE
fix(starter): publish configuration metadata

### DIFF
--- a/simba-spring-boot-starter/build.gradle.kts
+++ b/simba-spring-boot-starter/build.gradle.kts
@@ -14,6 +14,17 @@ plugins {
     alias(libs.plugins.kotlin.spring)
     kotlin("kapt")
 }
+kapt {
+    arguments {
+        arg(
+            "org.springframework.boot.configurationprocessor.additionalMetadataLocations",
+            file("src/main/resources").absolutePath
+        )
+    }
+}
+tasks.matching { it.name == "kaptKotlin" }.configureEach {
+    inputs.file("src/main/resources/META-INF/additional-spring-configuration-metadata.json")
+}
 java {
     registerFeature("springRedisSupport") {
         usingSourceSet(sourceSets[SourceSet.MAIN_SOURCE_SET_NAME])

--- a/simba-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/simba-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,67 @@
+{
+  "properties": [
+    {
+      "name": "simba.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether Simba auto-configuration is enabled.",
+      "sourceType": "me.ahoo.simba.spring.boot.starter.ConditionalOnSimbaEnabled",
+      "defaultValue": true
+    },
+    {
+      "name": "simba.jdbc.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether the JDBC backend is enabled.",
+      "sourceType": "me.ahoo.simba.spring.boot.starter.jdbc.JdbcProperties",
+      "defaultValue": true
+    },
+    {
+      "name": "simba.jdbc.initial-delay",
+      "type": "java.time.Duration",
+      "description": "Delay before the first JDBC contention attempt.",
+      "sourceType": "me.ahoo.simba.spring.boot.starter.jdbc.JdbcProperties",
+      "defaultValue": "0s"
+    },
+    {
+      "name": "simba.jdbc.ttl",
+      "type": "java.time.Duration",
+      "description": "Time-to-live of a JDBC owner lease.",
+      "sourceType": "me.ahoo.simba.spring.boot.starter.jdbc.JdbcProperties",
+      "defaultValue": "10s"
+    },
+    {
+      "name": "simba.jdbc.transition",
+      "type": "java.time.Duration",
+      "description": "Grace period for preferential JDBC owner renewal.",
+      "sourceType": "me.ahoo.simba.spring.boot.starter.jdbc.JdbcProperties",
+      "defaultValue": "6s"
+    },
+    {
+      "name": "simba.redis.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether the Redis backend is enabled.",
+      "sourceType": "me.ahoo.simba.spring.boot.starter.redis.RedisProperties",
+      "defaultValue": true
+    },
+    {
+      "name": "simba.redis.ttl",
+      "type": "java.time.Duration",
+      "description": "Time-to-live of a Redis owner lease.",
+      "sourceType": "me.ahoo.simba.spring.boot.starter.redis.RedisProperties",
+      "defaultValue": "10s"
+    },
+    {
+      "name": "simba.redis.transition",
+      "type": "java.time.Duration",
+      "description": "Grace period for preferential Redis owner renewal.",
+      "sourceType": "me.ahoo.simba.spring.boot.starter.redis.RedisProperties",
+      "defaultValue": "6s"
+    },
+    {
+      "name": "simba.zookeeper.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether the Zookeeper backend is enabled.",
+      "sourceType": "me.ahoo.simba.spring.boot.starter.zookeeper.ZookeeperProperties",
+      "defaultValue": true
+    }
+  ]
+}

--- a/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/ConfigurationMetadataTest.kt
+++ b/simba-spring-boot-starter/src/test/kotlin/me/ahoo/simba/spring/boot/starter/ConfigurationMetadataTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.simba.spring.boot.starter
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+
+class ConfigurationMetadataTest {
+    @Test
+    fun `published metadata lists every supported property`() {
+        val metadata = checkNotNull(
+            javaClass.classLoader.getResourceAsStream("META-INF/spring-configuration-metadata.json")
+        ).bufferedReader().use { it.readText() }
+        val properties = metadata.substringAfter("\"properties\": [").substringBefore("\"hints\"")
+        val propertyItems = PROPERTY.findAll(properties).associate { it.groupValues[1] to it.value }
+
+        assertThat(
+            propertyItems.keys,
+            containsInAnyOrder(*EXPECTED_PROPERTIES.map { it.first }.toTypedArray())
+        )
+        EXPECTED_PROPERTIES.forEach { (name, type, defaultValue) ->
+            assertThat(
+                propertyItems.getValue(name),
+                allOf(
+                    containsString("\"type\": \"$type\""),
+                    containsString("\"defaultValue\": $defaultValue")
+                )
+            )
+        }
+    }
+
+    companion object {
+        private val PROPERTY = Regex("""\{[^{}]*"name"\s*:\s*"([^"]+)"[^{}]*}""")
+        private val EXPECTED_PROPERTIES = listOf(
+            Triple("simba.enabled", "java.lang.Boolean", "true"),
+            Triple("simba.jdbc.enabled", "java.lang.Boolean", "true"),
+            Triple("simba.jdbc.initial-delay", "java.time.Duration", "\"0s\""),
+            Triple("simba.jdbc.ttl", "java.time.Duration", "\"10s\""),
+            Triple("simba.jdbc.transition", "java.time.Duration", "\"6s\""),
+            Triple("simba.redis.enabled", "java.lang.Boolean", "true"),
+            Triple("simba.redis.ttl", "java.time.Duration", "\"10s\""),
+            Triple("simba.redis.transition", "java.time.Duration", "\"6s\""),
+            Triple("simba.zookeeper.enabled", "java.lang.Boolean", "true")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- publish all nine supported Simba configuration properties with types, defaults, descriptions, and source types
- pass the official additional-metadata location to the Spring Boot processor under KAPT
- track the metadata source as a KAPT input so incremental builds cannot reuse stale output
- verify the generated metadata exposed on the runtime classpath

## Verification

- `./gradlew :simba-spring-boot-starter:clean :simba-spring-boot-starter:check :simba-spring-boot-starter:jar --no-daemon -Dkotlin.compiler.execution.strategy=in-process --max-workers=1`
- inspected `META-INF/spring-configuration-metadata.json` in the built JAR
- `git diff --check`
