### PR TITLE
fix(example): use current MySQL connector coordinate

### DIFF
--- a/simba-example/build.gradle.kts
+++ b/simba-example/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     annotationProcessor(platform(project(":simba-dependencies")))
     implementation("org.slf4j:slf4j-api")
 
-//    implementation("mysql:mysql-connector-java")
+//    implementation("com.mysql:mysql-connector-j")
 //    implementation(project(":simba-jdbc"))
 //    implementation("org.springframework.boot:spring-boot-starter-jdbc")
 


### PR DESCRIPTION
## Summary

- replace the obsolete `mysql:mysql-connector-java` example coordinate with `com.mysql:mysql-connector-j`

## Verification

- temporarily enabled the JDBC example dependency set
- `./gradlew :simba-example:clean :simba-example:compileJava :simba-example:dependencyInsight --dependency mysql-connector-j --configuration compileClasspath --no-daemon --max-workers=1`
- confirmed Boot 4.1 resolves `com.mysql:mysql-connector-j:9.7.0`
- restored the default Redis variant and ran `./gradlew :simba-example:check --no-daemon --max-workers=1`
- `git diff --check`
