### PR TITLE
docs: fix Zookeeper factory construction

### DIFF
--- a/wiki/guide/configuration.md
+++ b/wiki/guide/configuration.md
@@ -158,8 +158,12 @@ val factory = SpringRedisMutexContendServiceFactory(
 ```kotlin
 import me.ahoo.simba.zookeeper.ZookeeperMutexContendServiceFactory
 import org.apache.curator.framework.CuratorFramework
+import java.util.concurrent.ForkJoinPool
 
-val factory = ZookeeperMutexContendServiceFactory(curatorClient)
+val factory = ZookeeperMutexContendServiceFactory(
+    handleExecutor = ForkJoinPool.commonPool(),
+    curatorFramework = curatorClient
+)
 ```
 
 The Zookeeper backend delegates lease management to Curator, so no timing parameters are needed.

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -5002,8 +5002,12 @@ val factory = SpringRedisMutexContendServiceFactory(
 ```kotlin
 import me.ahoo.simba.zookeeper.ZookeeperMutexContendServiceFactory
 import org.apache.curator.framework.CuratorFramework
+import java.util.concurrent.ForkJoinPool
 
-val factory = ZookeeperMutexContendServiceFactory(curatorClient)
+val factory = ZookeeperMutexContendServiceFactory(
+    handleExecutor = ForkJoinPool.commonPool(),
+    curatorFramework = curatorClient
+)
 ```
 
 The Zookeeper backend delegates lease management to Curator, so no timing parameters are needed.

--- a/wiki/zh/guide/configuration.md
+++ b/wiki/zh/guide/configuration.md
@@ -158,8 +158,12 @@ val factory = SpringRedisMutexContendServiceFactory(
 ```kotlin
 import me.ahoo.simba.zookeeper.ZookeeperMutexContendServiceFactory
 import org.apache.curator.framework.CuratorFramework
+import java.util.concurrent.ForkJoinPool
 
-val factory = ZookeeperMutexContendServiceFactory(curatorClient)
+val factory = ZookeeperMutexContendServiceFactory(
+    handleExecutor = ForkJoinPool.commonPool(),
+    curatorFramework = curatorClient
+)
 ```
 
 Zookeeper 后端将租约管理委托给 Curator，因此不需要时序参数。


### PR DESCRIPTION
## Summary

- pass both required arguments to `ZookeeperMutexContendServiceFactory`
- keep English, Chinese, and `llms-full.txt` examples aligned

## Verification

- compiled the corrected snippet through `:simba-zookeeper:compileTestKotlin`
- `pnpm run build` in `wiki/`
- confirmed no `ZookeeperMutexContendServiceFactory(curatorClient)` call remains
- `git diff --check`
