### PR TITLE
docs: document runnable backend setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Simba aims to provide easy-to-use and flexible distributed lock services and sup
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.1.0</version>
+        <relativePath/>
+    </parent>
     <artifactId>demo</artifactId>
     <properties>
         <simba.version>simbaVersion</simba.version>
@@ -48,6 +54,9 @@ Simba aims to provide easy-to-use and flexible distributed lock services and sup
     
 </project>
 ```
+
+The starter provides Simba auto-configuration only. Add exactly one complete backend dependency set below; the backend infrastructure is still required.
+
 ### application.yaml
 
 ```yaml
@@ -72,6 +81,27 @@ spring:
 
 ``` kotlin
     implementation("me.ahoo.simba:simba-jdbc:${simbaVersion}")
+    implementation("org.springframework.boot:spring-boot-starter-jdbc")
+    runtimeOnly("com.mysql:mysql-connector-j")
+```
+
+> Maven
+
+```xml
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-jdbc</artifactId>
+    <version>${simba.version}</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-jdbc</artifactId>
+</dependency>
+<dependency>
+    <groupId>com.mysql</groupId>
+    <artifactId>mysql-connector-j</artifactId>
+    <scope>runtime</scope>
+</dependency>
 ```
 
 ```sql
@@ -92,6 +122,21 @@ create table simba_mutex
 
 ``` kotlin
     implementation("me.ahoo.simba:simba-spring-redis:${simbaVersion}")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+```
+
+> Maven
+
+```xml
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-spring-redis</artifactId>
+    <version>${simba.version}</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-data-redis</artifactId>
+</dependency>
 ```
 
 ### Optional-3: ZookeeperMutexContendService
@@ -101,6 +146,18 @@ create table simba_mutex
 ``` kotlin
     implementation("me.ahoo.simba:simba-zookeeper:${simbaVersion}")
 ```
+
+> Maven
+
+```xml
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-zookeeper</artifactId>
+    <version>${simba.version}</version>
+</dependency>
+```
+
+Also register a managed `CuratorFramework` bean as shown in the [Quick Start](https://simba.ahoo.me/guide/quick-start.html).
 
 ## Examples
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,6 +33,12 @@ Simba 旨在提供易用、灵活的分布式锁服务，支持多种存储后�
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.1.0</version>
+        <relativePath/>
+    </parent>
     <artifactId>demo</artifactId>
     <properties>
         <simba.version>simbaVersion</simba.version>
@@ -48,6 +54,9 @@ Simba 旨在提供易用、灵活的分布式锁服务，支持多种存储后�
     
 </project>
 ```
+
+starter 只提供 Simba 自动配置。请从下文选择并添加一套完整的后端依赖；对应的后端基础设施仍然是必需的。
+
 ### application.yaml
 
 ```yaml
@@ -72,6 +81,27 @@ spring:
 
 ``` kotlin
     implementation("me.ahoo.simba:simba-jdbc:${simbaVersion}")
+    implementation("org.springframework.boot:spring-boot-starter-jdbc")
+    runtimeOnly("com.mysql:mysql-connector-j")
+```
+
+> Maven
+
+```xml
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-jdbc</artifactId>
+    <version>${simba.version}</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-jdbc</artifactId>
+</dependency>
+<dependency>
+    <groupId>com.mysql</groupId>
+    <artifactId>mysql-connector-j</artifactId>
+    <scope>runtime</scope>
+</dependency>
 ```
 
 ```sql
@@ -92,6 +122,21 @@ create table simba_mutex
 
 ``` kotlin
     implementation("me.ahoo.simba:simba-spring-redis:${simbaVersion}")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+```
+
+> Maven
+
+```xml
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-spring-redis</artifactId>
+    <version>${simba.version}</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-data-redis</artifactId>
+</dependency>
 ```
 
 ### Optional-3: ZookeeperMutexContendService
@@ -101,6 +146,18 @@ create table simba_mutex
 ``` kotlin
     implementation("me.ahoo.simba:simba-zookeeper:${simbaVersion}")
 ```
+
+> Maven
+
+```xml
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-zookeeper</artifactId>
+    <version>${simba.version}</version>
+</dependency>
+```
+
+还需按照[快速开始](https://simba.ahoo.me/zh/guide/quick-start.html)注册一个由 Spring 管理的 `CuratorFramework` Bean。
 
 ## Examples
 

--- a/wiki/guide/quick-start.md
+++ b/wiki/guide/quick-start.md
@@ -15,27 +15,28 @@ This guide walks you through adding Simba to your project, configuring a backend
 
 ## Add Dependencies
 
-Simba is organized as a multi-module library. You need the core module plus exactly one backend module. If you use Spring Boot, the starter handles auto-configuration.
+The examples below target Spring Boot 4.1 and assume its dependency management is enabled. The Simba starter supplies auto-configuration, but each backend still needs its client/infrastructure dependencies. Choose exactly one complete set.
 
 ### Gradle Kotlin DSL
 
 ::: code-group
 
 ```kotlin [JDBC/MySQL]
+implementation("me.ahoo.simba:simba-spring-boot-starter:3.1.0")
 implementation("me.ahoo.simba:simba-jdbc:3.1.0")
+implementation("org.springframework.boot:spring-boot-starter-jdbc")
+runtimeOnly("com.mysql:mysql-connector-j")
 ```
 
 ```kotlin [Redis]
+implementation("me.ahoo.simba:simba-spring-boot-starter:3.1.0")
 implementation("me.ahoo.simba:simba-spring-redis:3.1.0")
+implementation("org.springframework.boot:spring-boot-starter-data-redis")
 ```
 
 ```kotlin [Zookeeper]
-implementation("me.ahoo.simba:simba-zookeeper:3.1.0")
-```
-
-```kotlin [Spring Boot Starter (add one backend)]
 implementation("me.ahoo.simba:simba-spring-boot-starter:3.1.0")
-implementation("me.ahoo.simba:simba-jdbc:3.1.0")  // or simba-spring-redis, or simba-zookeeper
+implementation("me.ahoo.simba:simba-zookeeper:3.1.0")
 ```
 
 :::
@@ -47,31 +48,51 @@ implementation("me.ahoo.simba:simba-jdbc:3.1.0")  // or simba-spring-redis, or s
 ```xml [JDBC/MySQL]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-spring-boot-starter</artifactId>
+    <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
     <artifactId>simba-jdbc</artifactId>
     <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-jdbc</artifactId>
+</dependency>
+<dependency>
+    <groupId>com.mysql</groupId>
+    <artifactId>mysql-connector-j</artifactId>
+    <scope>runtime</scope>
 </dependency>
 ```
 
 ```xml [Redis]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-spring-boot-starter</artifactId>
+    <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
     <artifactId>simba-spring-redis</artifactId>
     <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-data-redis</artifactId>
 </dependency>
 ```
 
 ```xml [Zookeeper]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
-    <artifactId>simba-zookeeper</artifactId>
+    <artifactId>simba-spring-boot-starter</artifactId>
     <version>3.1.0</version>
 </dependency>
-```
-
-```xml [Spring Boot Starter]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
-    <artifactId>simba-spring-boot-starter</artifactId>
+    <artifactId>simba-zookeeper</artifactId>
     <version>3.1.0</version>
 </dependency>
 ```
@@ -199,20 +220,60 @@ scheduler.stop()
 
 ## Spring Boot Auto-Configuration
 
-With the Spring Boot starter, Simba auto-configures everything. You just set the enabled flag for your chosen backend.
+The starter creates a `MutexContendServiceFactory` only after the selected backend infrastructure is available. Configure the matching `DataSource`, Redis connection, or `CuratorFramework` bean.
 
-**application.yml**
+::: code-group
 
-```yaml
+```yaml [JDBC application.yml]
 simba:
   jdbc:
     enabled: true
     initial-delay: 0s
     ttl: 10s
     transition: 6s
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/simba_db
+    username: root
+    password: root
 ```
 
-The auto-configuration creates the `MutexContendServiceFactory` bean for you. Inject it and use it directly:
+```yaml [Redis application.yml]
+simba:
+  redis:
+    enabled: true
+    ttl: 10s
+    transition: 6s
+
+spring:
+  data:
+    redis:
+      url: redis://localhost:6379
+```
+
+```kotlin [Zookeeper Bean]
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.CuratorFrameworkFactory
+import org.apache.curator.retry.ExponentialBackoffRetry
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+class ZookeeperConfiguration {
+    @Bean(initMethod = "start", destroyMethod = "close")
+    fun curatorFramework(): CuratorFramework = CuratorFrameworkFactory.newClient(
+        "localhost:2181",
+        ExponentialBackoffRetry(1000, 3)
+    )
+}
+```
+
+:::
+
+For JDBC, also create the `simba_mutex` table with the [MySQL initialization script](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/init-script/init-simba-mysql.sql).
+
+After those prerequisites exist, auto-configuration creates the `MutexContendServiceFactory` bean. Inject it and use it directly:
 
 ```kotlin
 import org.springframework.stereotype.Component

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -4531,27 +4531,28 @@ This guide walks you through adding Simba to your project, configuring a backend
 
 ## Add Dependencies
 
-Simba is organized as a multi-module library. You need the core module plus exactly one backend module. If you use Spring Boot, the starter handles auto-configuration.
+The examples below target Spring Boot 4.1 and assume its dependency management is enabled. The Simba starter supplies auto-configuration, but each backend still needs its client/infrastructure dependencies. Choose exactly one complete set.
 
 ### Gradle Kotlin DSL
 
 ::: code-group
 
 ```kotlin [JDBC/MySQL]
+implementation("me.ahoo.simba:simba-spring-boot-starter:3.1.0")
 implementation("me.ahoo.simba:simba-jdbc:3.1.0")
+implementation("org.springframework.boot:spring-boot-starter-jdbc")
+runtimeOnly("com.mysql:mysql-connector-j")
 ```
 
 ```kotlin [Redis]
+implementation("me.ahoo.simba:simba-spring-boot-starter:3.1.0")
 implementation("me.ahoo.simba:simba-spring-redis:3.1.0")
+implementation("org.springframework.boot:spring-boot-starter-data-redis")
 ```
 
 ```kotlin [Zookeeper]
-implementation("me.ahoo.simba:simba-zookeeper:3.1.0")
-```
-
-```kotlin [Spring Boot Starter (add one backend)]
 implementation("me.ahoo.simba:simba-spring-boot-starter:3.1.0")
-implementation("me.ahoo.simba:simba-jdbc:3.1.0")  // or simba-spring-redis, or simba-zookeeper
+implementation("me.ahoo.simba:simba-zookeeper:3.1.0")
 ```
 
 :::
@@ -4563,31 +4564,51 @@ implementation("me.ahoo.simba:simba-jdbc:3.1.0")  // or simba-spring-redis, or s
 ```xml [JDBC/MySQL]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-spring-boot-starter</artifactId>
+    <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
     <artifactId>simba-jdbc</artifactId>
     <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-jdbc</artifactId>
+</dependency>
+<dependency>
+    <groupId>com.mysql</groupId>
+    <artifactId>mysql-connector-j</artifactId>
+    <scope>runtime</scope>
 </dependency>
 ```
 
 ```xml [Redis]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-spring-boot-starter</artifactId>
+    <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
     <artifactId>simba-spring-redis</artifactId>
     <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-data-redis</artifactId>
 </dependency>
 ```
 
 ```xml [Zookeeper]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
-    <artifactId>simba-zookeeper</artifactId>
+    <artifactId>simba-spring-boot-starter</artifactId>
     <version>3.1.0</version>
 </dependency>
-```
-
-```xml [Spring Boot Starter]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
-    <artifactId>simba-spring-boot-starter</artifactId>
+    <artifactId>simba-zookeeper</artifactId>
     <version>3.1.0</version>
 </dependency>
 ```
@@ -4715,20 +4736,60 @@ scheduler.stop()
 
 ## Spring Boot Auto-Configuration
 
-With the Spring Boot starter, Simba auto-configures everything. You just set the enabled flag for your chosen backend.
+The starter creates a `MutexContendServiceFactory` only after the selected backend infrastructure is available. Configure the matching `DataSource`, Redis connection, or `CuratorFramework` bean.
 
-**application.yml**
+::: code-group
 
-```yaml
+```yaml [JDBC application.yml]
 simba:
   jdbc:
     enabled: true
     initial-delay: 0s
     ttl: 10s
     transition: 6s
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/simba_db
+    username: root
+    password: root
 ```
 
-The auto-configuration creates the `MutexContendServiceFactory` bean for you. Inject it and use it directly:
+```yaml [Redis application.yml]
+simba:
+  redis:
+    enabled: true
+    ttl: 10s
+    transition: 6s
+
+spring:
+  data:
+    redis:
+      url: redis://localhost:6379
+```
+
+```kotlin [Zookeeper Bean]
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.CuratorFrameworkFactory
+import org.apache.curator.retry.ExponentialBackoffRetry
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+class ZookeeperConfiguration {
+    @Bean(initMethod = "start", destroyMethod = "close")
+    fun curatorFramework(): CuratorFramework = CuratorFrameworkFactory.newClient(
+        "localhost:2181",
+        ExponentialBackoffRetry(1000, 3)
+    )
+}
+```
+
+:::
+
+For JDBC, also create the `simba_mutex` table with the [MySQL initialization script](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/init-script/init-simba-mysql.sql).
+
+After those prerequisites exist, auto-configuration creates the `MutexContendServiceFactory` bean. Inject it and use it directly:
 
 ```kotlin
 import org.springframework.stereotype.Component

--- a/wiki/zh/guide/quick-start.md
+++ b/wiki/zh/guide/quick-start.md
@@ -15,27 +15,28 @@ description: 几分钟内上手 Simba。添加依赖、选择后端，用几行�
 
 ## 添加依赖
 
-Simba 采用多模块组织。你需要核心模块加上恰好一个后端模块。如果使用 Spring Boot，starter 会处理自动配置。
+以下示例面向 Spring Boot 4.1，并假定已启用其依赖管理。Simba starter 提供自动配置，但每个后端仍需要对应的客户端和基础设施依赖。请选择一套完整组合。
 
 ### Gradle Kotlin DSL
 
 ::: code-group
 
 ```kotlin [JDBC/MySQL]
+implementation("me.ahoo.simba:simba-spring-boot-starter:3.1.0")
 implementation("me.ahoo.simba:simba-jdbc:3.1.0")
+implementation("org.springframework.boot:spring-boot-starter-jdbc")
+runtimeOnly("com.mysql:mysql-connector-j")
 ```
 
 ```kotlin [Redis]
+implementation("me.ahoo.simba:simba-spring-boot-starter:3.1.0")
 implementation("me.ahoo.simba:simba-spring-redis:3.1.0")
+implementation("org.springframework.boot:spring-boot-starter-data-redis")
 ```
 
 ```kotlin [Zookeeper]
-implementation("me.ahoo.simba:simba-zookeeper:3.1.0")
-```
-
-```kotlin [Spring Boot Starter（还需添加一个后端）]
 implementation("me.ahoo.simba:simba-spring-boot-starter:3.1.0")
-implementation("me.ahoo.simba:simba-jdbc:3.1.0")  // 或 simba-spring-redis，或 simba-zookeeper
+implementation("me.ahoo.simba:simba-zookeeper:3.1.0")
 ```
 
 :::
@@ -47,31 +48,51 @@ implementation("me.ahoo.simba:simba-jdbc:3.1.0")  // 或 simba-spring-redis，�
 ```xml [JDBC/MySQL]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-spring-boot-starter</artifactId>
+    <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
     <artifactId>simba-jdbc</artifactId>
     <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-jdbc</artifactId>
+</dependency>
+<dependency>
+    <groupId>com.mysql</groupId>
+    <artifactId>mysql-connector-j</artifactId>
+    <scope>runtime</scope>
 </dependency>
 ```
 
 ```xml [Redis]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
+    <artifactId>simba-spring-boot-starter</artifactId>
+    <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>me.ahoo.simba</groupId>
     <artifactId>simba-spring-redis</artifactId>
     <version>3.1.0</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-data-redis</artifactId>
 </dependency>
 ```
 
 ```xml [Zookeeper]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
-    <artifactId>simba-zookeeper</artifactId>
+    <artifactId>simba-spring-boot-starter</artifactId>
     <version>3.1.0</version>
 </dependency>
-```
-
-```xml [Spring Boot Starter]
 <dependency>
     <groupId>me.ahoo.simba</groupId>
-    <artifactId>simba-spring-boot-starter</artifactId>
+    <artifactId>simba-zookeeper</artifactId>
     <version>3.1.0</version>
 </dependency>
 ```
@@ -199,20 +220,60 @@ scheduler.stop()
 
 ## Spring Boot 自动配置
 
-使用 Spring Boot starter 后，Simba 会自动配置一切。你只需为你选择的后端设置启用标志即可。
+只有在所选后端的基础设施可用后，starter 才会创建 `MutexContendServiceFactory`。请配置对应的 `DataSource`、Redis 连接或 `CuratorFramework` Bean。
 
-**application.yml**
+::: code-group
 
-```yaml
+```yaml [JDBC application.yml]
 simba:
   jdbc:
     enabled: true
     initial-delay: 0s
     ttl: 10s
     transition: 6s
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/simba_db
+    username: root
+    password: root
 ```
 
-自动配置会为你创建 `MutexContendServiceFactory` Bean。注入它即可直接使用：
+```yaml [Redis application.yml]
+simba:
+  redis:
+    enabled: true
+    ttl: 10s
+    transition: 6s
+
+spring:
+  data:
+    redis:
+      url: redis://localhost:6379
+```
+
+```kotlin [Zookeeper Bean]
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.CuratorFrameworkFactory
+import org.apache.curator.retry.ExponentialBackoffRetry
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+class ZookeeperConfiguration {
+    @Bean(initMethod = "start", destroyMethod = "close")
+    fun curatorFramework(): CuratorFramework = CuratorFrameworkFactory.newClient(
+        "localhost:2181",
+        ExponentialBackoffRetry(1000, 3)
+    )
+}
+```
+
+:::
+
+使用 JDBC 时，还需通过 [MySQL 初始化脚本](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/init-script/init-simba-mysql.sql) 创建 `simba_mutex` 表。
+
+满足这些前置条件后，自动配置会创建 `MutexContendServiceFactory` Bean。注入它即可直接使用：
 
 ```kotlin
 import org.springframework.stereotype.Component


### PR DESCRIPTION
## Summary

- replace incomplete backend-only Quick Start snippets with complete Spring Boot dependency sets
- document JDBC `DataSource`/schema, Redis connection, and managed `CuratorFramework` prerequisites
- add equivalent Maven dependencies and Boot dependency management
- keep English, Chinese, root README, and `llms-full.txt` content aligned

## Verification

- compiled the documented Zookeeper configuration against the project classpath
- `pnpm run build` in `wiki/`
- validated both README Maven POM snippets with `xmllint`
- confirmed the English Quick Start and its `llms-full.txt` copy are identical
- `git diff --check`
