### PR TITLE
ci: verify release tag matches project version

### DIFF
--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -20,7 +20,25 @@ permissions:
   contents: read
 
 jobs:
+  verify-release-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Verify release tag matches project version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          release_version="${RELEASE_TAG#v}"
+          project_version="$(sed -n 's/^version=//p' gradle.properties)"
+          if [ -z "$project_version" ] || [ "$release_version" != "$project_version" ]; then
+            echo "::error::Release tag '$RELEASE_TAG' does not match project version '$project_version'."
+            exit 1
+          fi
+
   github-deploy:
+    needs: verify-release-version
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -45,6 +63,7 @@ jobs:
           SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
   central-deploy:
+    needs: verify-release-version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- normalize the release tag's optional `v` prefix and compare it with `gradle.properties`
- fail before either publishing job receives credentials or uploads artifacts
- make both GitHub Packages and Central publishing depend on the same verification job

## Root cause

The release event and Gradle project version were independent, so a release created from a stale or unbumped tag could publish the wrong coordinates and partially succeed across repositories.

## Verification

- executed the workflow script with `RELEASE_TAG=v3.1.0` (passes)
- executed it with `RELEASE_TAG=v3.1.1` (fails with an Actions error)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yml`
- `git diff --check`
