### PR TITLE
ci: check all example backend variants

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -36,6 +36,29 @@ jobs:
       - name: Test Simba-Core
         run: ./gradlew simba-core:clean simba-core:check
 
+  simba-example-test:
+    name: Simba Example (${{ matrix.backend }})
+    needs: [ simba-core-test ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [jdbc, redis, zookeeper]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github
+          settings-path: ${{ github.workspace }}
+
+      - name: Test Simba-Example
+        run: ./gradlew simba-example:clean simba-example:check -PexampleBackend=${{ matrix.backend }}
+
   simba-spring-redis-test:
     name: Simba Spring Redis Test
     needs: [ simba-core-test ]

--- a/simba-example/build.gradle.kts
+++ b/simba-example/build.gradle.kts
@@ -24,20 +24,29 @@ application {
     mainClass.set("me.ahoo.simba.example.ExampleApp")
 }
 
+val exampleBackend = providers.gradleProperty("exampleBackend").orElse("redis").get()
+
 dependencies {
     implementation(platform(project(":simba-dependencies")))
     annotationProcessor(platform(project(":simba-dependencies")))
     implementation("org.slf4j:slf4j-api")
 
-//    implementation("com.mysql:mysql-connector-j")
-//    implementation(project(":simba-jdbc"))
-//    implementation("org.springframework.boot:spring-boot-starter-jdbc")
+    when (exampleBackend) {
+        "jdbc" -> {
+            implementation(project(":simba-jdbc"))
+            implementation("org.springframework.boot:spring-boot-starter-jdbc")
+            runtimeOnly("com.mysql:mysql-connector-j")
+        }
+        "redis" -> {
+            implementation(project(":simba-spring-redis"))
+            implementation("org.springframework.boot:spring-boot-starter-data-redis")
+        }
+        "zookeeper" -> implementation(project(":simba-zookeeper"))
+        else -> error("Unsupported exampleBackend '$exampleBackend'. Expected jdbc, redis, or zookeeper.")
+    }
 
-    implementation(project(":simba-spring-redis"))
-    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
-//    implementation(project(":simba-zookeeper"))
     implementation(project(":simba-spring-boot-starter"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
## Summary

- replace commented dependency toggles with `-PexampleBackend=jdbc|redis|zookeeper`
- preserve Redis as the default example backend
- add a CI matrix that runs `simba-example:check` against all three dependency graphs
- reject unsupported backend names during Gradle configuration

## Root cause

The example module was not part of any CI check, and its alternative backend dependencies were only comments. Broken coordinates and incompatible variants could therefore remain undetected.

## Verification

- `./gradlew :simba-example:clean :simba-example:check -PexampleBackend=jdbc --no-daemon --max-workers=1`
- same check with `redis` and `zookeeper`
- confirmed `-PexampleBackend=invalid` fails with the expected message
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yml`
- `git diff --check`
