### PR TITLE
docs: fix Quick Start schema citation

### DIFF
--- a/wiki/guide/quick-start.md
+++ b/wiki/guide/quick-start.md
@@ -271,7 +271,7 @@ class ZookeeperConfiguration {
 
 :::
 
-For JDBC, also create the `simba_mutex` table with the [MySQL initialization script](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/init-script/init-simba-mysql.sql).
+For JDBC, also create the `simba_mutex` table with [`simba-jdbc/src/init-script/init-simba-mysql.sql:17`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/init-script/init-simba-mysql.sql#L17).
 
 After those prerequisites exist, auto-configuration creates the `MutexContendServiceFactory` bean. Inject it and use it directly:
 

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -4787,7 +4787,7 @@ class ZookeeperConfiguration {
 
 :::
 
-For JDBC, also create the `simba_mutex` table with the [MySQL initialization script](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/init-script/init-simba-mysql.sql).
+For JDBC, also create the `simba_mutex` table with [`simba-jdbc/src/init-script/init-simba-mysql.sql:17`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/init-script/init-simba-mysql.sql#L17).
 
 After those prerequisites exist, auto-configuration creates the `MutexContendServiceFactory` bean. Inject it and use it directly:
 

--- a/wiki/zh/guide/quick-start.md
+++ b/wiki/zh/guide/quick-start.md
@@ -271,7 +271,7 @@ class ZookeeperConfiguration {
 
 :::
 
-使用 JDBC 时，还需通过 [MySQL 初始化脚本](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/init-script/init-simba-mysql.sql) 创建 `simba_mutex` 表。
+使用 JDBC 时，还需通过 [`simba-jdbc/src/init-script/init-simba-mysql.sql:17`](https://github.com/Ahoo-Wang/Simba/blob/main/simba-jdbc/src/init-script/init-simba-mysql.sql#L17) 创建 `simba_mutex` 表。
 
 满足这些前置条件后，自动配置会创建 `MutexContendServiceFactory` Bean。注入它即可直接使用：
 


### PR DESCRIPTION
## Summary

- use the wiki-required `file_path:line` citation label for the JDBC schema
- add the direct `#L17` anchor to the `simba_mutex` table definition
- keep English, Chinese, and `llms-full.txt` copies aligned

## Review feedback

Addresses the actionable review thread raised after #472 merged.

## Verification

- `pnpm run build` in `wiki/`
- confirmed the English Quick Start and `llms-full.txt` copy are identical
- `git diff --check`
