### PR TITLE
test: introduce fluent-assert

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ pnpm run fix:mermaid
 
 - Tests use JUnit Platform with Kotlin/JVM and Java 17.
 - Common backend behavior is captured in `simba-test/src/main/kotlin/me/ahoo/simba/test/MutexContendServiceSpec.kt`.
-- Existing tests use Hamcrest assertions (`MatcherAssert.assertThat`, `Matchers.equalTo`) and MockK where mocking is needed.
+- Prefer FluentAssert's `.assert()` extensions for new Kotlin assertions; preserve existing Hamcrest assertions unless the test is already being changed. Use MockK where mocking is needed.
 - Run a single test class with `./gradlew <module>:test --tests fully.qualified.TestClass`.
 - CI runs `simba-core`, then Redis, Zookeeper, and JDBC module checks from `.github/workflows/integration-test.yml`.
 - Redis CI starts a Redis service. JDBC CI starts MySQL and loads `simba-jdbc/src/init-script/init-simba-mysql.sql`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,9 +98,11 @@ configure(libraryProjects) {
     dependencies {
         api(platform(dependenciesProject))
         testImplementation(platform(rootProject.libs.junit.bom))
+        testImplementation(platform(rootProject.libs.fluent.assert.bom))
         implementation("com.google.guava:guava")
         implementation("org.slf4j:slf4j-api")
         testImplementation("ch.qos.logback:logback-classic")
+        testImplementation("me.ahoo.test:fluent-assert-core")
         testImplementation("org.junit.jupiter:junit-jupiter-api")
         testImplementation("org.junit.jupiter:junit-jupiter-params")
         testImplementation("org.hamcrest:hamcrest")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ guava = "33.6.0-jre"
 commons-io = "2.22.0"
 kotlin-logging = "8.0.4"
 junit = "6.1.3"
+fluent-assert = "1.1.0"
 hamcrest = "3.0"
 mockk = "1.14.11"
 detekt-formatting = "1.23.8"
@@ -26,6 +27,7 @@ guava = { module = "com.google.guava:guava", version.ref = "guava" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt-formatting" }
@@ -36,4 +38,3 @@ kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publish-plugin" }
-

--- a/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexOwnerTest.kt
+++ b/simba-core/src/test/kotlin/me/ahoo/simba/core/MutexOwnerTest.kt
@@ -13,109 +13,108 @@
 
 package me.ahoo.simba.core
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class MutexOwnerTest {
     @Test
     fun `isOwner returns true when ids match`() {
         val owner = MutexOwner("A", 0, 100, 200)
-        assertThat(owner.isOwner("A"), equalTo(true))
+        owner.isOwner("A").assert().isTrue()
     }
 
     @Test
     fun `isOwner returns false when ids differ`() {
         val owner = MutexOwner("A", 0, 100, 200)
-        assertThat(owner.isOwner("B"), equalTo(false))
+        owner.isOwner("B").assert().isFalse()
     }
 
     @Test
     fun `isInTtl is true when ttlAt greater than currentAt`() {
         val owner = FixedClockOwner("A", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
-        assertThat(owner.isInTtl, equalTo(true))
+        owner.isInTtl.assert().isTrue()
     }
 
     @Test
     fun `isInTtl is false when ttlAt equals currentAt`() {
         val owner = FixedClockOwner("A", ttlAt = 100, transitionAt = 300, fixedCurrentAt = 100)
-        assertThat(owner.isInTtl, equalTo(false))
+        owner.isInTtl.assert().isFalse()
     }
 
     @Test
     fun `isInTtl is false when ttlAt less than currentAt`() {
         val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 300, fixedCurrentAt = 100)
-        assertThat(owner.isInTtl, equalTo(false))
+        owner.isInTtl.assert().isFalse()
     }
 
     @Test
     fun `isInTtl contenderId is true for owner in ttl`() {
         val owner = FixedClockOwner("A", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
-        assertThat(owner.isInTtl("A"), equalTo(true))
+        owner.isInTtl("A").assert().isTrue()
     }
 
     @Test
     fun `isInTtl contenderId is false for owner expired`() {
         val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 300, fixedCurrentAt = 100)
-        assertThat(owner.isInTtl("A"), equalTo(false))
+        owner.isInTtl("A").assert().isFalse()
     }
 
     @Test
     fun `isInTtl contenderId is false for non owner even if in ttl`() {
         val owner = FixedClockOwner("A", ttlAt = 200, transitionAt = 300, fixedCurrentAt = 100)
-        assertThat(owner.isInTtl("B"), equalTo(false))
+        owner.isInTtl("B").assert().isFalse()
     }
 
     @Test
     fun `isInTransition is true at equality boundary`() {
         val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 100, fixedCurrentAt = 100)
-        assertThat(owner.isInTransition, equalTo(true))
+        owner.isInTransition.assert().isTrue()
     }
 
     @Test
     fun `isInTransition is false when transitionAt less than currentAt`() {
         val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 50, fixedCurrentAt = 100)
-        assertThat(owner.isInTransition, equalTo(false))
+        owner.isInTransition.assert().isFalse()
     }
 
     @Test
     fun `isInTransitionOf is true for owner in transition`() {
         val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 200, fixedCurrentAt = 100)
-        assertThat(owner.isInTransitionOf("A"), equalTo(true))
+        owner.isInTransitionOf("A").assert().isTrue()
     }
 
     @Test
     fun `isInTransitionOf is false for non owner`() {
         val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 200, fixedCurrentAt = 100)
-        assertThat(owner.isInTransitionOf("B"), equalTo(false))
+        owner.isInTransitionOf("B").assert().isFalse()
     }
 
     @Test
     fun `hasOwner is true at transition boundary`() {
         val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 100, fixedCurrentAt = 100)
-        assertThat(owner.hasOwner(), equalTo(true))
+        owner.hasOwner().assert().isTrue()
     }
 
     @Test
     fun `hasOwner is false when transitionAt less than currentAt`() {
         val owner = FixedClockOwner("A", ttlAt = 50, transitionAt = 50, fixedCurrentAt = 100)
-        assertThat(owner.hasOwner(), equalTo(false))
+        owner.hasOwner().assert().isFalse()
     }
 
     @Test
     fun `default args yield inTtl and inTransition true`() {
         val owner = MutexOwner("A")
-        assertThat(owner.isInTtl, equalTo(true))
-        assertThat(owner.isInTransition, equalTo(true))
-        assertThat(owner.hasOwner(), equalTo(true))
+        owner.isInTtl.assert().isTrue()
+        owner.isInTransition.assert().isTrue()
+        owner.hasOwner().assert().isTrue()
     }
 
     @Test
     fun `NONE constant has empty ownerId and is expired`() {
-        assertThat(MutexOwner.NONE.ownerId, equalTo(MutexOwner.NONE_OWNER_ID))
-        assertThat(MutexOwner.NONE_OWNER_ID, equalTo(""))
-        assertThat(MutexOwner.NONE.isInTtl, equalTo(false))
-        assertThat(MutexOwner.NONE.isInTransition, equalTo(false))
-        assertThat(MutexOwner.NONE.hasOwner(), equalTo(false))
+        MutexOwner.NONE.ownerId.assert().isEqualTo(MutexOwner.NONE_OWNER_ID)
+        MutexOwner.NONE_OWNER_ID.assert().isEmpty()
+        MutexOwner.NONE.isInTtl.assert().isFalse()
+        MutexOwner.NONE.isInTransition.assert().isFalse()
+        MutexOwner.NONE.hasOwner().assert().isFalse()
     }
 }

--- a/simba-test/build.gradle.kts
+++ b/simba-test/build.gradle.kts
@@ -2,6 +2,8 @@ description = "The Technology Compatibility Kit"
 
 dependencies {
     api(project(":simba-core"))
+    api(platform(libs.fluent.assert.bom))
+    api("me.ahoo.test:fluent-assert-core")
     api("org.hamcrest:hamcrest")
     implementation("org.junit.jupiter:junit-jupiter-api")
 }

--- a/simba-test/src/main/kotlin/me/ahoo/simba/test/MutexContendServiceSpec.kt
+++ b/simba-test/src/main/kotlin/me/ahoo/simba/test/MutexContendServiceSpec.kt
@@ -20,8 +20,7 @@ import me.ahoo.simba.core.MutexOwner
 import me.ahoo.simba.core.MutexState
 import me.ahoo.simba.schedule.AbstractScheduler
 import me.ahoo.simba.schedule.ScheduleConfig
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -62,10 +61,10 @@ abstract class MutexContendServiceSpec {
         })
         contendService.start()
         acquiredFuture.join()
-        assertThat(contendService.isOwner, equalTo(true))
+        contendService.isOwner.assert().isTrue()
         contendService.stop()
         releasedFuture.join()
-        assertThat(contendService.isOwner, equalTo(false))
+        contendService.isOwner.assert().isFalse()
     }
 
     @Test
@@ -97,16 +96,16 @@ abstract class MutexContendServiceSpec {
         })
         contendService.start()
         acquiredFuture.join()
-        assertThat(contendService.isOwner, equalTo(true))
+        contendService.isOwner.assert().isTrue()
         contendService.stop()
         releasedFuture.join()
-        assertThat(contendService.isOwner, equalTo(false))
+        contendService.isOwner.assert().isFalse()
         contendService.start()
         acquiredFuture2.join()
-        assertThat(contendService.isOwner, equalTo(true))
+        contendService.isOwner.assert().isTrue()
         contendService.stop()
         releasedFuture2.join()
-        assertThat(contendService.isOwner, equalTo(false))
+        contendService.isOwner.assert().isFalse()
     }
 
     @Test
@@ -128,13 +127,13 @@ abstract class MutexContendServiceSpec {
         })
         contendService.start()
         acquiredFuture.join()
-        assertThat(contendService.isOwner, equalTo(true))
+        contendService.isOwner.assert().isTrue()
         TimeUnit.SECONDS.sleep(3)
-        assertThat(contendService.afterOwner.ownerId, equalTo(contendService.contender.contenderId))
-        assertThat(contendService.isOwner, equalTo(true))
+        contendService.afterOwner.ownerId.assert().isEqualTo(contendService.contender.contenderId)
+        contendService.isOwner.assert().isTrue()
         contendService.stop()
         releasedFuture.join()
-        assertThat(contendService.isOwner, equalTo(false))
+        contendService.isOwner.assert().isFalse()
     }
 
     @Test
@@ -150,27 +149,27 @@ abstract class MutexContendServiceSpec {
                     override fun onAcquired(mutexState: MutexState) {
                         currentOwnerIdRef.set(mutexState.after.ownerId)
                         super.onAcquired(mutexState)
-                        assertThat(count.incrementAndGet(), equalTo(1))
+                        count.incrementAndGet().assert().isEqualTo(1)
                     }
 
                     override fun onReleased(mutexState: MutexState) {
                         super.onReleased(mutexState)
-                        assertThat(count.decrementAndGet(), equalTo(0))
+                        count.decrementAndGet().assert().isZero()
                     }
                 })
             contendService.start()
             contendServiceList.add(contendService)
         }
         TimeUnit.SECONDS.sleep(30)
-        assertThat(count.get(), equalTo(1))
+        count.get().assert().isEqualTo(1)
         val currentOwnerId = currentOwnerIdRef.get()
         for (contendService in contendServiceList) {
             if (contendService.afterOwner.ownerId.isNotBlank()) {
-                assertThat(contendService.afterOwner.ownerId, equalTo(currentOwnerId))
+                contendService.afterOwner.ownerId.assert().isEqualTo(currentOwnerId)
             }
         }
         val ownerCount = contendServiceList.count { it.contenderId == currentOwnerId }
-        assertThat(ownerCount, equalTo(1))
+        ownerCount.assert().isEqualTo(1)
     }
 
     @Test
@@ -188,11 +187,11 @@ abstract class MutexContendServiceSpec {
                 countDownLatch.countDown()
             }
         }
-        assertThat(testScheduler.running, equalTo(false))
+        testScheduler.running.assert().isFalse()
         testScheduler.start()
-        assertThat(testScheduler.running, equalTo(true))
-        assertThat(countDownLatch.await(5, TimeUnit.SECONDS), equalTo(true))
+        testScheduler.running.assert().isTrue()
+        countDownLatch.await(5, TimeUnit.SECONDS).assert().isTrue()
         testScheduler.stop()
-        assertThat(testScheduler.running, equalTo(false))
+        testScheduler.running.assert().isFalse()
     }
 }


### PR DESCRIPTION
## Summary\n\n- add the FluentAssert 1.1.0 BOM and core test dependency\n- expose FluentAssert from the shared simba-test TCK main source set\n- migrate MutexOwnerTest and MutexContendServiceSpec as executable adoption\n- document FluentAssert as the preferred style for new Kotlin assertions\n\n## Why\n\nThe Simba testing skill already recommends FluentAssert, but the project did not provide the dependency. The shared TCK also compiles from main, so it needs its own API dependency for downstream backend implementations.\n\n## Validation\n\n- ./gradlew :simba-core:test --tests me.ahoo.simba.core.MutexOwnerTest\n- ./gradlew :simba-test:check :simba-core:check\n- git diff --check