### PR TITLE
docs(skill): align redis lease semantics

### DIFF
--- a/skills/simba/SKILL.md
+++ b/skills/simba/SKILL.md
@@ -272,5 +272,5 @@ For tests, use the `simba-testing` skill. In short:
 2. **Blocking callbacks**: `onAcquired`/`onReleased` run on a shared executor. Long-running work in these callbacks will delay other contenders' notifications.
 3. **Multiple backends enabled**: If both Redis and JDBC are on the classpath without explicit disambiguation, Spring will fail to autowire `MutexContendServiceFactory`.
 4. **Clock skew with JDBC**: The JDBC backend uses DB server time (`currentDbAt`) to avoid clock skew across application nodes. Ensure all nodes point to the same DB.
-5. **Redis key expiration**: If the Redis key expires (process crash), the transition period gives the old owner a chance to reclaim. After transition, the next contender in the sorted-set queue is notified via Pub/Sub.
+5. **Redis release vs expiration**: Explicit release wakes the oldest queued contender through its personal Pub/Sub channel. Natural key expiration publishes nothing; contenders retry on their existing schedule around hard expiry.
 6. **Zookeeper path conflicts**: The Zookeeper backend creates paths at `/simba/{mutex}`. Don't use the same mutex name for unrelated locks.

--- a/skills/simba/references/backend-internals.md
+++ b/skills/simba/references/backend-internals.md
@@ -19,7 +19,7 @@ The sorted set acts as the wait queue. Contenders are notified via Pub/Sub when 
 
 For the current owner to renew (extend TTL):
 1. Checks if the lock is held by this contender (`GET key == contenderId`).
-2. If yes: `SET XX PX ttlMs` to extend the expiry. Returns `contenderId@@ttlMs`.
+2. If yes: `SET XX PX (ttlMs + transitionMs)` to renew the full hard lease. Returns `contenderId@@hardLeaseMs`.
 3. If no: returns the current owner info so the contender knows it lost the lock.
 
 ### mutex_release.lua


### PR DESCRIPTION
## Summary\n\n- document Redis guard renewal as the full ttl plus transition lease\n- distinguish explicit release Pub/Sub wake-up from silent key expiration\n\n## Why\n\nThe skill still described the pre-fix shortened guard lease and implied that Redis expiration publishes a wake-up event.\n\n## Validation\n\n- matched SpringRedisMutexContendService guard/acquire arguments\n- matched mutex_guard.lua and ContendPeriod retry behavior\n- skill-creator quick_validate.py skills/simba\n- git diff --check