### PR TITLE
docs(skill): fix locker lifecycle test

### DIFF
--- a/skills/simba-testing/SKILL.md
+++ b/skills/simba-testing/SKILL.md
@@ -90,18 +90,19 @@ Mock the factory and verify the locker lifecycle:
 import me.ahoo.simba.locker.SimbaLocker
 
 @Test
-fun `locker should acquire and release`() {
+fun `locker should stop running service on close`() {
     val mockService = mockk<MutexContendService>(relaxed = true)
     every { mockFactory.createMutexContendService(any()) } returns mockService
+    every { mockService.running } returns true
 
     val locker = SimbaLocker("test-lock", mockFactory)
-    // acquire() will block, so in unit tests we typically don't call it directly
-    // Instead test the code that uses the locker
     locker.close()
 
     verify { mockService.stop() }
 }
 ```
+
+Stub `running` as true because `close()` calls `stop()` only for an active contend service.
 
 ## TCK — Extending MutexContendServiceSpec
 


### PR DESCRIPTION
## Summary\n\n- stub the mocked contend service as running before closing SimbaLocker\n- rename the example test to match the behavior it verifies\n- explain the active-service precondition for stop\n\n## Why\n\nSimbaLocker.close only calls stop when the contend service is running. A relaxed MockK boolean defaults to false, so the previous verify block failed.\n\n## Validation\n\n- matched SimbaLocker.close implementation\n- skill-creator quick_validate.py skills/simba-testing\n- git diff --check