### PR TITLE
docs(skill): complete scheduler leadership test

### DIFF
--- a/skills/simba-testing/SKILL.md
+++ b/skills/simba-testing/SKILL.md
@@ -139,11 +139,29 @@ Do not silently add Testcontainers to this repository's tests. If CI isolation i
 Test that scheduled work runs only on the leader:
 
 ```kotlin
+import io.mockk.capture
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import me.ahoo.simba.core.MutexContendService
+import me.ahoo.simba.core.MutexContendServiceFactory
+import me.ahoo.simba.core.MutexContender
+import me.ahoo.simba.core.MutexOwner
+import me.ahoo.simba.core.MutexState
 import me.ahoo.simba.schedule.AbstractScheduler
 import me.ahoo.simba.schedule.ScheduleConfig
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @Test
 fun `scheduler should run work only when leader`() {
+    val contenderSlot = slot<MutexContender>()
+    val mockService = mockk<MutexContendService>(relaxed = true)
+    val mockFactory = mockk<MutexContendServiceFactory>()
+    every { mockFactory.createMutexContendService(capture(contenderSlot)) } returns mockService
     val workLatch = CountDownLatch(1)
     val scheduler = object : AbstractScheduler("test-scheduler", mockFactory) {
         override val config = ScheduleConfig.delay(Duration.ZERO, Duration.ofMillis(100))
@@ -154,11 +172,14 @@ fun `scheduler should run work only when leader`() {
     }
 
     scheduler.start()
-    // Simulate acquiring leadership by triggering the contender
-    // ...
-
-    workLatch.await(5, TimeUnit.SECONDS).assert().isTrue()
-    scheduler.stop()
+    val contender = contenderSlot.captured
+    try {
+        contender.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(contender.contenderId)))
+        workLatch.await(5, TimeUnit.SECONDS).assert().isTrue()
+    } finally {
+        contender.onReleased(MutexState(MutexOwner(contender.contenderId), MutexOwner.NONE))
+        scheduler.stop()
+    }
 }
 ```
 

--- a/skills/simba-testing/SKILL.md
+++ b/skills/simba-testing/SKILL.md
@@ -155,6 +155,7 @@ import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 @Test
 fun `scheduler should run work only when leader`() {
@@ -162,22 +163,31 @@ fun `scheduler should run work only when leader`() {
     val mockService = mockk<MutexContendService>(relaxed = true)
     val mockFactory = mockk<MutexContendServiceFactory>()
     every { mockFactory.createMutexContendService(capture(contenderSlot)) } returns mockService
-    val workLatch = CountDownLatch(1)
+    val leader = AtomicBoolean(false)
+    val leaderWork = CountDownLatch(1)
+    val outsideLeadershipWork = CountDownLatch(1)
     val scheduler = object : AbstractScheduler("test-scheduler", mockFactory) {
         override val config = ScheduleConfig.delay(Duration.ZERO, Duration.ofMillis(100))
         override val worker = "test"
         override fun work() {
-            workLatch.countDown()
+            if (leader.get()) leaderWork.countDown() else outsideLeadershipWork.countDown()
         }
     }
 
     scheduler.start()
     val contender = contenderSlot.captured
     try {
+        outsideLeadershipWork.await(200, TimeUnit.MILLISECONDS).assert().isFalse()
+        leader.set(true)
         contender.onAcquired(MutexState(MutexOwner.NONE, MutexOwner(contender.contenderId)))
-        workLatch.await(5, TimeUnit.SECONDS).assert().isTrue()
-    } finally {
+        leaderWork.await(5, TimeUnit.SECONDS).assert().isTrue()
         contender.onReleased(MutexState(MutexOwner(contender.contenderId), MutexOwner.NONE))
+        leader.set(false)
+        outsideLeadershipWork.await(200, TimeUnit.MILLISECONDS).assert().isFalse()
+    } finally {
+        if (leader.getAndSet(false)) {
+            contender.onReleased(MutexState(MutexOwner(contender.contenderId), MutexOwner.NONE))
+        }
         scheduler.stop()
     }
 }


### PR DESCRIPTION
## Summary\n\n- make the scheduler test snippet self-contained\n- capture the scheduler's internal contender through MockK\n- trigger leadership acquisition and release explicitly\n- guarantee scheduler cleanup in finally\n\n## Why\n\nThe previous template left leadership simulation as an ellipsis, so copied tests never scheduled work and timed out.\n\n## Validation\n\n- ./gradlew :simba-core:test --tests me.ahoo.simba.schedule.AbstractSchedulerTest\n- skill-creator quick_validate.py for both Simba skills\n- git diff --check