### PR TITLE
test(tck): propagate ownership invariant failures

### DIFF
--- a/simba-test/src/main/kotlin/me/ahoo/simba/test/MutexContendServiceSpec.kt
+++ b/simba-test/src/main/kotlin/me/ahoo/simba/test/MutexContendServiceSpec.kt
@@ -139,6 +139,7 @@ abstract class MutexContendServiceSpec {
     @Test
     open fun multiContend() {
         val count = AtomicInteger(0)
+        val invariantViolation = AtomicReference<AssertionError>()
         val currentOwnerIdRef = AtomicReference<String>()
         val contendServiceList: MutableList<MutexContendService> = ArrayList(10)
         repeat(10) {
@@ -149,18 +150,31 @@ abstract class MutexContendServiceSpec {
                     override fun onAcquired(mutexState: MutexState) {
                         currentOwnerIdRef.set(mutexState.after.ownerId)
                         super.onAcquired(mutexState)
-                        count.incrementAndGet().assert().isEqualTo(1)
+                        val ownerCount = count.incrementAndGet()
+                        if (ownerCount != 1) {
+                            invariantViolation.compareAndSet(
+                                null,
+                                AssertionError("Expected exactly one owner after acquire, but was $ownerCount.")
+                            )
+                        }
                     }
 
                     override fun onReleased(mutexState: MutexState) {
                         super.onReleased(mutexState)
-                        count.decrementAndGet().assert().isZero()
+                        val ownerCount = count.decrementAndGet()
+                        if (ownerCount != 0) {
+                            invariantViolation.compareAndSet(
+                                null,
+                                AssertionError("Expected no owner after release, but was $ownerCount.")
+                            )
+                        }
                     }
                 })
             contendService.start()
             contendServiceList.add(contendService)
         }
         TimeUnit.SECONDS.sleep(30)
+        invariantViolation.get()?.let { throw it }
         count.get().assert().isEqualTo(1)
         val currentOwnerId = currentOwnerIdRef.get()
         for (contendService in contendServiceList) {


### PR DESCRIPTION
## Summary

- record the first multi-contender ownership invariant violation from asynchronous callbacks
- rethrow the recorded failure on the JUnit test thread

## Root cause

Callback assertions execute under safeNotifyOwner, which catches Throwable. A transient dual-owner assertion could therefore be logged and swallowed before the final steady-state assertion.

## Validation

- ./gradlew :simba-test:check
- git diff --check